### PR TITLE
Fix an error when saving field values using with Vizy

### DIFF
--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -88,6 +88,12 @@ class ColourSwatches extends Field implements PreviewableFieldInterface
                 {
                     return $value;
                 }
+                
+                // Check to see if this is already an array, which happens in some cases (Vizy)
+                if (is_array($value)) {
+                    $value = json_encode($value);
+                }
+                
                 // quick array transform so that we can ensure and `required fields` fire an error
                 $valueData = (array)json_decode($value);
                 // if we have actual data return model


### PR DESCRIPTION
Related to https://github.com/percipioglobal/craft-colour-swatches/issues/66 but this is to provide support to Vizy, as we store the content of the field as:

`{"label":"Primary Color","color":"#5468ff"}`

Due to how Vizy unwraps its field content from stored JSON into arrays, the value received by the `normalizeValue` function is already an array, which throws an error without a guard for this.

You could probably structure this better, but this was meant to be as small a change as possible. In particular, the value passed to `ColourSwatchesModel` needs to be a JSON string, so that's the reason for converting an array back into a string, only for it to be converted to an array again. Feel free to change this if you prefer.

You could check if `is_string` and also use `decodeIfJson()`, which is similar to Craft's table field: 
https://github.com/craftcms/cms/blob/a859f09df6d90bfa92ca1818418eab508c0e82df/src/fields/Table.php#L376-L380