### PR TITLE
Support string keys for 'palettes' array elements

### DIFF
--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -43,7 +43,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface
     /** @var string */
     public $palette = null;
 
-    /** @var int */
+    /** @var int|string */
     public $default = null;
 
     // Static Methods
@@ -136,7 +136,9 @@ class ColourSwatches extends Field implements PreviewableFieldInterface
         //if nothing got set, use the default if that exists
         if(!$saveValue){
             foreach($settingsPalette as $key => $palette){
-                if(is_array($palette) && ($key + 1) == $this->default){
+                $paletteId = is_int($key) ? ($key + 1) : $key;
+
+                if(is_array($palette) && $paletteId == $this->default){
                     $saveValue = $palette;
                 }
             }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -8,5 +8,5 @@ class Settings extends Model
 {
     public $colors = [];
     public $palettes = [];
-    public $default = 0;
+    public $default = null;
 }


### PR DESCRIPTION
@michtio , we have a use case where we want to define a common Colour Swatches configuration file with palettes that is used across multiple projects as a base configuration. Then each project will have it's own specific configuration file which is used to modify or add to the default set of colours in a palette specifically for that project. The final set of colours available to a project will be obtained by doing a recursive array merge of the common Colour Swatches configuration file with the project specific configuration file.

However, in order to do this, we need it to be possible to use string keys as the index for the elements (colour settings) in the `palettes` array like so:

```php
return [
    'palettes' => [
        'Backgrounds' => [
            'black' => [
                'label' => 'Black',
                'color' => '#000000',
                'default' => false,
            ],
            'blue' => [
                'label' => 'Blue',
                'color' => '#161746',
                'default' => false,
            ],
            'green' => [
                'label' => 'Green',
                'color' => '#008000',
                'default' => false,
            ],
        ],
    ]
];
```

The plugin nearly supports this already, apart from a few minor cases where integer keys are assumed.

Any chance you could merge this in and roll out a new release?
