### PR TITLE
Readme: Fix codeblock syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ This plugin requires Craft CMS 3.5.0 or later.
 To install the plugin, follow these instructions.
 
 1. Open your terminal and go to your Craft project:
-
-        `cd /path/to/project`
+```
+    cd /path/to/project
+```
 
 2. Then tell Composer to load the plugin:
-
-        `composer require percipioglobal/craft-colour-swatches`
-
+```
+    composer require percipioglobal/craft-colour-swatches
+```
 3. In the Control Panel, go to Settings → Plugins and click the "Install" button for Colour Swatches.
 
 ## Configuring Colour Swatches


### PR DESCRIPTION
The former syntax resulted in additional backticks inside the codeblock because the indentation was already renderes as a codeblock implicitly:

![2022-05-06T16:48:32,033986624+02:00](https://user-images.githubusercontent.com/2489598/167157302-e5343a4f-9c0a-45ac-b3e3-1226cc8a0cfb.png)

Best,
Felix