### PR TITLE
 Set configuration via Control Panel #106

### DIFF
--- a/src/ColourSwatches.php
+++ b/src/ColourSwatches.php
@@ -47,6 +47,11 @@ class ColourSwatches extends Plugin
      */
     public string $schemaVersion = '1.4.3';
 
+    /**
+     * @var bool
+     */
+    public bool $hasCpSettings = true;
+
     // Public Methods
     // =========================================================================
 
@@ -82,5 +87,16 @@ class ColourSwatches extends Plugin
     protected function createSettingsModel(): Settings
     {
         return new Settings();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function settingsHtml(): ?string
+    {
+        return Craft::$app->view->renderTemplate(
+            'colour-swatches/_settings',
+            ['settings' => $this->getSettings()]
+        );
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -31,7 +31,26 @@ class Settings extends Model
     {
         return [
             [['colors', 'palettes'], 'required'],
-            [['colors', 'palettes'], 'array'],
+            [['colors', 'palettes'], function ($attribute, $params) {
+                if (!is_array($this->colors)) {
+                    $this->addError('colors', Craft::t('colour-swatches', 'colors is not array!'));
+                }
+
+                if (!is_array($this->palettes)) {
+                    $this->addError('palettes', Craft::t('colour-swatches', 'palettes is not array!'));
+                }
+            }],
+            [['palettes'], 'filter', 'filter' => function ($palettes) {
+                foreach ($palettes as &$palette) {
+                    foreach ($palette as &$color) {
+                        if (is_string($color['color'])) {
+                            $color['color'] = json_decode($color['color'], true);
+                        }
+                    }
+                }
+                
+                return $palettes;
+            }]
         ];
     }
 }

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -1,0 +1,84 @@
+{# @var craft \craft\web\twig\variables\CraftVariable #}
+{#
+/**
+ * color-swatches plugin for Craft CMS
+ *
+ * ColourSwatches Settings
+ *
+ * @author    Percipio Global Ltd.
+ * @copyright Copyright (c) 2023 Percipio Global Ltd.
+ * @link      https://percipio.london
+ * @package   Colour Swatches
+ * @since     4.3.0
+ */
+#}
+
+{% import "_includes/forms" as forms %}
+
+<div id="settings" class="color-swatches-options">
+    {{ craft.cp.field(forms.editableTable({
+            instructions: 'Define the available colors.'|t('colour-swatches'),
+            id: 'colors',
+            name: 'colors',
+            addRowLabel: 'Add a colour'|t('colour-swatches'),
+            cols: {
+                label: {
+                    heading: 'Label'|t('colour-swatches'),
+                    type: 'singleline',
+                },
+                color: {
+                    heading: 'Hex Colours (comma seperated)'|t('colour-swatches'),
+                    type: 'singleline',
+                },
+                default: {
+                    heading: 'Default?'|t('colour-swatches'),
+                    type: 'checkbox', class: 'thin',
+                },
+                class: {
+                    heading: 'Css class to go with the palette'|t('colour-swatches'),
+                    type: 'singleline',
+                },
+            },
+            rows: settings.colors,
+            allowAdd: true,
+            allowReorder: true,
+            allowDelete: true,
+        }), {
+            label: 'Colors'|t('colour-swatches'),
+            id: 'colors',
+            name: 'colors'
+    })|raw }}
+
+    {% for name, palette in settings['palettes'] %}
+        <div class="palette">
+            {{ craft.cp.field(forms.editableTable({
+                instructions: 'Define the available colors.'|t('colour-swatches'),
+                id: 'palettes-' ~ name,
+                name: 'palettes[' ~ name ~ ']',
+                addRowLabel: 'Add a colour'|t('colour-swatches'),
+                cols: {
+                    label: {
+                        heading: 'Label'|t('colour-swatches'),
+                        type: 'singleline',
+                    },
+                    color: {
+                        heading: 'Hex Colours (comma seperated)'|t('colour-swatches'),
+                        type: 'text',
+                    },
+                    default: {
+                        heading: 'Default?'|t('colour-swatches'),
+                        type: 'checkbox', class: 'thin',
+                    }
+                },
+                rows: palette|map(p => p|merge({ color: p.color|json_encode})),
+                allowAdd: true,
+                allowReorder: true,
+                allowDelete: true,
+                class: 'palette-table'
+            }), {
+                label: 'Palette {name}'|t('colour-swatches', { name: name }),
+                id: 'palettes[' ~ name ~ ']'
+            })|raw }}
+        </div>
+    {% endfor %}
+</div>


### PR DESCRIPTION
Referring to https://github.com/percipioglobal/craft-colour-swatches/issues/106

With this commit it's possible to:
- add new colors (like in the field settings)
- edit existing palettes
