### PR TITLE
Release 5.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /build/*
 /yarn-error.log
 
+# TEST CACHE
+.phpunit.cache
+
 # MISC FILES
 .cache
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed translation file named `color-swatches.php` not matching plugin handle `colour-swatches` (translations were silently ignored)
 - Fixed dead `if ($this)` guard in `collection()` method
 - Fixed `validateJson()` decoding JSON twice redundantly
+- Fixed swatch CSS class and default flag being dropped on save: the CP input only posts label, colour, and handle, so saved values are now enriched from the field's option definitions again
 - Fixed string-colour swatch options not including the stable `handle` in their saved value, unlike array-colour options
 - Fixed the Red/Amber example palette in `config.php` starting with a purple colour value instead of red
 - Fixed `m220503_104406_namespace_migration::safeDown()` echoing the wrong migration name, and completed migration docblocks ([#154](https://github.com/craftpulse/craft-colour-swatches/issues/154))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## 5.3.0 - 2026-07-16
+## 5.2.0 - 2026-07-16
 
 > **Critical:** This release includes security fixes, GraphQL breaking changes, and fixes for long-standing data loss issues. All users should update immediately.
-
-> Note: version 5.2.0 was never published, so this release contains every change since 5.1.0.
 
 ### Security
 - Fixed XSS vulnerability in colour option templates where user-controlled colour values were output with `|parseRefs|raw` in style attributes
@@ -22,9 +20,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Search keyword support — entries can now be found via Craft search by swatch label, handle, CSS class, or colour value ([#113](https://github.com/craftpulse/craft-colour-swatches/issues/113))
 - Validation rules on the colour swatch value model ([#148](https://github.com/craftpulse/craft-colour-swatches/issues/148))
 - Swatch values now store a stable `handle`, so palette labels can be renamed in the config file or field settings without existing selections losing their value ([#141](https://github.com/craftpulse/craft-colour-swatches/issues/141))
+- Existing swatch values are upgraded automatically on update: a migration queues batched resave jobs that write the stable handle and search keywords for every element type using a Colour Swatches field
 
 ### Deprecated
-- Deprecated the `colors()`, `labels()`, `default()`, and `class()` accessor methods on the value model — access the `color`, `label`, `default`, and `class` properties directly. These methods will be removed in 6.0.0.
+- Deprecated the `colors()`, `labels()`, `default()`, and `class()` accessor methods on the value model, access the `color`, `label`, `default`, and `class` properties directly. These methods will be removed in 6.0.0.
 
 ### Fixed
 - Fixed `serializeValue()` mutating field state (`$this->options`, `$this->default`) as a side effect, causing inconsistent behaviour on multi-site saves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - **GraphQL Mode setting** — new "GraphQL Mode" select in field settings (when GQL is enabled) to toggle between "Full data" (returns `ColourSwatches_SwatchData` object with label, handle, color, class) and "Label only" (returns plain string). Defaults to full data for all fields.
 - `handle` field exposed in the GraphQL `ColourSwatches_SwatchData` type
+- Search keyword support — entries can now be found via Craft search by swatch label, handle, CSS class, or colour value ([#113](https://github.com/craftpulse/craft-colour-swatches/issues/113))
+- Validation rules on the colour swatch value model ([#148](https://github.com/craftpulse/craft-colour-swatches/issues/148))
+
+### Deprecated
+- Deprecated the `colors()`, `labels()`, `default()`, and `class()` accessor methods on the value model — access the `color`, `label`, `default`, and `class` properties directly. These methods will be removed in 6.0.0.
 
 ### Fixed
 - Fixed `serializeValue()` mutating field state (`$this->options`, `$this->default`) as a side effect, causing inconsistent behaviour on multi-site saves
@@ -28,6 +33,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed translation file named `color-swatches.php` not matching plugin handle `colour-swatches` (translations were silently ignored)
 - Fixed dead `if ($this)` guard in `collection()` method
 - Fixed `validateJson()` decoding JSON twice redundantly
+- Fixed string-colour swatch options not including the stable `handle` in their saved value, unlike array-colour options
+- Fixed the Red/Amber example palette in `config.php` starting with a purple colour value instead of red
+- Fixed `m220503_104406_namespace_migration::safeDown()` echoing the wrong migration name, and completed migration docblocks ([#154](https://github.com/craftpulse/craft-colour-swatches/issues/154))
 
 ### Changed
 - **Breaking (GraphQL):** GraphQL type name changed from per-field-handle names to a single shared `ColourSwatches_SwatchData` type. Queries using inline fragments on the old type names will need updating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## 5.3.0 - 2026-04-20
+
+> **Critical:** This release includes security fixes from 5.2.1, GraphQL breaking changes, and fixes for long-standing data loss issues. All users should update immediately.
+
+### Security
+- Fixed XSS vulnerability in colour option templates where user-controlled colour values were output with `|parseRefs|raw` in style attributes
+- Fixed potential JS injection via unescaped field handle in `registerJs()` call
+- Fixed unescaped colour values in element index preview HTML
+
+### Added
+- **GraphQL Mode setting** — new "GraphQL Mode" select in field settings (when GQL is enabled) to toggle between "Full data" (returns `ColourSwatches_SwatchData` object with label, handle, color, class) and "Label only" (returns plain string). Defaults to full data for all fields.
+- `handle` field exposed in the GraphQL `ColourSwatches_SwatchData` type
+
+### Fixed
+- Fixed `serializeValue()` mutating field state (`$this->options`, `$this->default`) as a side effect, causing inconsistent behaviour on multi-site saves
+- Fixed handle generation inconsistency between PHP (`toCamelCase`) and Twig template (`|kebab` changed to `|camel`), which caused handles to be `null` after resave (#141)
+- Fixed double-JSON-encoding of colour values in GraphQL resolver that produced `"\"#ef4444\""` instead of `"#ef4444"`
+- Fixed duplicate `$paletteOptions` block in field settings (dead code)
+- Fixed loose `== 1` comparisons for default detection replaced with `!empty()`
+- Fixed double-compound DOM ID on hidden input (`id ~ namespacedId` changed to `id`)
+- Fixed translation file named `color-swatches.php` not matching plugin handle `colour-swatches` (translations were silently ignored)
+- Fixed dead `if ($this)` guard in `collection()` method
+- Fixed `validateJson()` decoding JSON twice redundantly
+
+### Changed
+- **Breaking (GraphQL):** GraphQL type name changed from per-field-handle names to a single shared `ColourSwatches_SwatchData` type. Queries using inline fragments on the old type names will need updating.
+- **Breaking (GraphQL):** Colour values in GraphQL responses are no longer double-encoded. If your client-side code was double-parsing JSON, remove the extra parse step.
+- Moved `Collection::macro('recursive')` registration from model constructor to plugin `init()` where global state registration belongs
+- Extracted `_resolveOptions()` method to centralize config file palette resolution (was duplicated in `normalizeValue` and `serializeValue`)
+- Removed unnecessary `beforeSave()` override that was a fragile no-op
+- Updated PHP requirement from `^8.0.2` to `^8.2` to match Craft 5
+- Updated all file headers from Craft CMS 3.x/4.x to 5.x with current CraftPulse branding
+- Updated support and documentation URLs from `percipio.london`/`v4` to `craftpulse.com`/`v5`
+- Added `aria-label` to colour swatch buttons for screen reader accessibility
+- Annotated broken migration `m220503` with `@deprecated` pointing to its fix migration
+
 ## 5.1.0 - 2024-10-28
 ### Added
 - Added a `collection` function to the field that will return a recursive laravel collection for easier use in twig templates and to do manipulations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## 5.3.0 - 2026-04-20
+## 5.3.0 - 2026-07-16
 
-> **Critical:** This release includes security fixes from 5.2.1, GraphQL breaking changes, and fixes for long-standing data loss issues. All users should update immediately.
+> **Critical:** This release includes security fixes, GraphQL breaking changes, and fixes for long-standing data loss issues. All users should update immediately.
+
+> Note: version 5.2.0 was never published, so this release contains every change since 5.1.0.
 
 ### Security
 - Fixed XSS vulnerability in colour option templates where user-controlled colour values were output with `|parseRefs|raw` in style attributes
@@ -19,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `handle` field exposed in the GraphQL `ColourSwatches_SwatchData` type
 - Search keyword support — entries can now be found via Craft search by swatch label, handle, CSS class, or colour value ([#113](https://github.com/craftpulse/craft-colour-swatches/issues/113))
 - Validation rules on the colour swatch value model ([#148](https://github.com/craftpulse/craft-colour-swatches/issues/148))
+- Swatch values now store a stable `handle`, so palette labels can be renamed in the config file or field settings without existing selections losing their value ([#141](https://github.com/craftpulse/craft-colour-swatches/issues/141))
 
 ### Deprecated
 - Deprecated the `colors()`, `labels()`, `default()`, and `class()` accessor methods on the value model — access the `color`, `label`, `default`, and `class` properties directly. These methods will be removed in 6.0.0.
@@ -37,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed string-colour swatch options not including the stable `handle` in their saved value, unlike array-colour options
 - Fixed the Red/Amber example palette in `config.php` starting with a purple colour value instead of red
 - Fixed `m220503_104406_namespace_migration::safeDown()` echoing the wrong migration name, and completed migration docblocks ([#154](https://github.com/craftpulse/craft-colour-swatches/issues/154))
+- Fixed deprecated DOM ID generation in the field input
 
 ### Changed
 - **Breaking (GraphQL):** GraphQL type name changed from per-field-handle names to a single shared `ColourSwatches_SwatchData` type. Queries using inline fragments on the old type names will need updating.
@@ -49,6 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Updated support and documentation URLs from `percipio.london`/`v4` to `craftpulse.com`/`v5`
 - Added `aria-label` to colour swatch buttons for screen reader accessibility
 - Annotated broken migration `m220503` with `@deprecated` pointing to its fix migration
+- Rebranded plugin icons and updated the example config
 
 ## 5.1.0 - 2024-10-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,45 +2,56 @@
 
 Create custom colour palettes with flexibility & control.
 
-# Colour Swatches plugin for Craft CMS 4+
+# Colour Swatches plugin for Craft CMS 5
 
-Instead of providing a user a full color picker, Colour Swatches is a configurable a fieldtype that gives an admin the ability to provide a selection of colours for a user to choose from. This allows you to create branded colour palettes with a bank of classnames ready to use in your templates.
+Instead of giving editors a full colour picker, Colour Swatches is a configurable field type that lets you provide a curated selection of colours to choose from. Build branded colour palettes with associated CSS class names and custom attributes, ready to use in your templates and GraphQL queries.
 
 ![Screenshot](./resources/img/colour-swatches-1.png)
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0 or later.
+- Craft CMS 5.0.0 or later
+- PHP 8.2 or later
+
+Looking for the Craft 4 version? Use the [`v4` branch](https://github.com/craftpulse/craft-colour-swatches/tree/v4) (`craftpulse/craft-colour-swatches: ^4.0`).
 
 ## Installation
-
-To install the plugin, follow these instructions.
 
 1. Open your terminal and go to your Craft project:
 
         cd /path/to/project
 
-2. Then tell Composer to load the plugin:
+2. Tell Composer to load the plugin:
 
         composer require craftpulse/craft-colour-swatches
 
 3. In the Control Panel, go to Settings → Plugins and click the "Install" button for Colour Swatches.
 
+## Upgrading from 5.1.0
+
+Version 5.2.0 introduces stable handles on stored swatch values, so palette labels can be renamed without existing selections losing their value. The upgrade runs automatically:
+
+- A migration queues batched resave jobs for every element type that uses a Colour Swatches field.
+- Once the queue has processed them, all stored values carry a handle and are indexed for search.
+- On deployments, `php craft up` applies the migration; make sure a queue runner processes the queued jobs afterwards.
+
+Also note the GraphQL changes in 5.2.0, covered in the [GraphQL](#graphql) section below. They are breaking if you query swatch fields.
+
 ## Configuring Colour Swatches
+
 ### Using the field settings
 
-Create a Colour Swatches field and provide label and hex value options. Multiple colours are possible by seperating them with a comma.
+Create a Colour Swatches field and provide a label, hex value, optional default, and an optional CSS class per option. Multiple colours are possible by separating them with a comma, which renders as a gradient swatch.
 
 ![Screenshot](./resources/img/colour-swatches-3.png)
 
-#### When using Colour Swatches with the field settings
-
-You can access both the label and color in your template. By default, the label will display:
+You can access the label, colour, and class in your template. By default, the label will display:
 
 ```twig
     {{ fieldName }}
     {{ fieldName.label }}
     {{ fieldName.color }}
+    {{ fieldName.class }}
 ```
 
 ```twig
@@ -49,308 +60,199 @@ You can access both the label and color in your template. By default, the label 
     {% endfor %}
 ```
 
-If you want more granular control with your colour palettes, use the configuration file option below.
+If you want more granular control over your colour palettes, use the configuration file option below.
 
 ### Using the config file
 
-You can use a `config/colour-swatches.php` config file file to predefine the possible colours, define different palettes and add lables, classnames or other attributes to your colours.
+You can use a `config/colour-swatches.php` config file to predefine the possible colours, define different palettes, and add labels, class names, or any custom attributes to your colours.
 
-Take a look at the [config file](https://github.com/craftpulse/craft-colour-swatches/blob/v5/src/config.php) in this repo for an example.
+Take a look at the [config file](https://github.com/craftpulse/craft-colour-swatches/blob/v5/src/config.php) in this repo for a full example.
 
 ```php
 return [
 
-    // Custom  palettes, fixed options [label, default (boolean), colour (array(colour, customOptions)) ]
+    // Custom palettes, fixed options [label, handle, default (boolean), class, colour (array(colour, customOptions))]
     'palettes' => [
-        'Tailwind' => [  // custom label (required)
+        'Tailwind' => [  // palette name (required)
             [
-                'label'   => 'Red', // custom label (required)
-                'default' => true,  // default could be true/false (option is required)
-                'color'   =>  [
+                'label'   => 'Red',   // shown to editors (required)
+                'handle'  => 'red',   // stable identifier (optional, recommended)
+                'default' => true,    // whether this option is preselected
+                'class'   => null,    // extra classes to go along with this palette
+                'color'   => [
                     [
-                        'color'             => '#ef4444',               // the colour shown in the fieldtype (required)
-                        'background'        => 'bg-red-500',            // optional / custom attribute
-                        'backgroundHover'   => 'hover:bg-red-700',      // optional / custom attribute
-                        'text'              => 'text-white',            // optional / custom attribute
-                        'textHover'         => 'hover:text-zinc-200'    // optional / custom attribute
-                    ]
-                ]
-            ],
-            [
-                'label'   => 'Amber',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#f59e0b',               
-                        'background'        => 'bg-amber-500',
-                        'backgroundHover'   => 'hover:bg-amber-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
-            ],
-            [
-                'label'   => 'Green',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#22c55e',              
-                        'background'        => 'bg-green-500',
-                        'backgroundHover'   => 'hover:bg-green-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
-            ],
-            [
-                'label'   => 'Blue',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#3b82f6',              
-                        'background'        => 'bg-blue-500',
-                        'backgroundHover'   => 'hover:bg-blue-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
-            ],
-            [
-                'label'   => 'Purple',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#a855f7',              
-                        'background'        => 'bg-purple-500',
-                        'backgroundHover'   => 'hover:bg-purple-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
-            ],
-            [
-                'label'   => 'Yellow/Emerald',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#eab308',              
-                        'background'        => 'bg-yellow-500',
-                        'backgroundHover'   => 'hover:bg-yellow-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
+                        'color'           => '#ef4444',            // the colour shown in the field (required)
+                        'background'      => 'bg-red-500',         // optional / custom attribute
+                        'backgroundHover' => 'hover:bg-red-700',   // optional / custom attribute
+                        'text'            => 'text-white',         // optional / custom attribute
+                        'textHover'       => 'hover:text-zinc-200' // optional / custom attribute
                     ],
-                    [
-                        'color'             => '#059669',               
-                        'background'        => 'bg-emerald-600',
-                        'backgroundHover'   => 'hover:bg-emerald-800',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
+                ],
             ],
             [
-                'label'   => 'Red/Amber',
+                'label'   => 'Sunset',
+                'handle'  => 'sunset',
                 'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#a855f7',              
-                        'background'        => 'bg-red-500',
-                        'backgroundHover'   => 'hover:bg-red-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ],
-                    [
-                        'color'             => '#f59e0b',               
-                        'background'        => 'bg-amber-500',
-                        'backgroundHover'   => 'hover:bg-amber-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
+                'class'   => 'bg-sunset',
+                'color'   => [
+                    // multiple colours render as a gradient swatch
+                    ['color' => '#f59e0b'],
+                    ['color' => '#ef4444'],
+                ],
             ],
-            [
-                'label'   => 'Sky/Rose',
-                'default' => false,
-                'color'   =>  [
-                    [
-                        'color'             => '#0ea5e9',               
-                        'background'        => 'bg-sky-500',
-                        'backgroundHover'   => 'hover:bg-sky-700',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ],
-                    [
-                        'color'             => '#e11d48',               
-                        'background'        => 'bg-rose-600',
-                        'backgroundHover'   => 'hover:bg-rose-800',
-                        'text'              => 'text-white',
-                        'textHover'         => 'hover:text-zinc-200'
-                    ]
-                ]
+        ],
+    ],
+
+    // Fallback colours used when a field has "Use config options" enabled
+    // but no palette selected
+    'colors' => [
+        [
+            'label'   => 'Green',
+            'handle'  => 'green',
+            'default' => false,
+            'class'   => null,
+            'color'   => [
+                ['color' => '#22c55e'],
             ],
-        ]
-    ]
+        ],
+    ],
 
 ];
 ```
 
-In your field settings you can then have the possibility to have it use the predefined colours.
+In your field settings you then have the option to use the predefined palettes.
 
 ![Screenshot](./resources/img/colour-swatches-2.png)
 
 #### Making changes to your config file
 
-If have entries using Colour Swatches and you make changes to your config file, you will need to resave your entries for new information from your config file to be pulled into your entry data.
+Stored swatch values are enriched from your config on save. If you change colours, classes, or custom attributes in the config file, resave your entries so the stored data picks up the changes:
 
-From the command line you can run Crafts `./craft resave/entries` and your entries will be populated with any changes to from your `colour-swatches.php` config file.
-
-**Note:** As of version 5.2.0, Colour Swatches uses a silent handle system for stability. When you first save entries, a handle is automatically generated from the label (e.g., "Red" becomes "red"). This handle is used to match colours even if you change the label later.
-
+```bash
+php craft resave/entries
+```
 
 #### Using Colour Swatches
 
-You can access both the label and color in your template. By default, the label will display:
+You can access the label, colour, class, and any custom attributes in your template. By default, the label will display:
 
 ```twig
     {{ fieldName }}
     {{ fieldName.label }}
     {{ fieldName.color }}
-    {{ fieldName.customAttribute }}
+    {{ fieldName.class }}
 ```
 
-If you're using multiple colours you will need to loop through your color array
+If you're using multiple colours you will need to loop through your colour array:
 
 ```twig
-    {% for field in fieldName.color %}
-        {{ field.color }}
-        {{ field.customAttribute }}
+    {% for color in fieldName.color %}
+        {{ color.color }}
+        {{ color.customAttribute }}
     {% endfor %}
 ```
 
 #### Using Collections
 
-The `collection()` method (added in v5.1.0) returns a recursive Laravel collection for easier manipulation:
+The `collection()` method (added in 5.1.0) returns a recursive Laravel collection for easier manipulation:
 
 ```twig
 {# Get all hex values as an array #}
 {% set hexValues = fieldName.collection().pluck('color').all() %}
 
-{# Filter colors by a custom attribute #}
+{# Filter colours by a custom attribute #}
 {% set darkColors = fieldName.collection()
     .filter(c => c.background is defined and 'dark' in c.background) %}
-
-{# Map to custom format #}
-{% set cssVars = fieldName.collection()
-    .map(c => '--color: ' ~ c.color ~ ';')
-    .implode(' ') %}
 
 {# Chain multiple operations #}
 {% set backgrounds = fieldName.collection()
     .pluck('background')
     .filter()
     .unique()
-    .all() 
+    .all()
 %}
 
-{# Get count of colors #}
-{% set colorCount = fieldName.collection().count() %}
-
-{# Create CSS gradient from colors #}
+{# Create a CSS gradient from the colours #}
 {% set gradient = 'linear-gradient(' ~ fieldName.collection().pluck('color').implode(', ') ~ ')' %}
 <div style="background: {{ gradient }}">Gradient background</div>
 ```
 
 ## Changing Labels
 
-By default, colour options are identified by their labels. The plugin now uses a silent handle system to maintain stability.
+Swatch values are matched by a stable handle first, then by label as a fallback for values saved before 5.2.0. This means you can rename labels in your config file or field settings without existing selections losing their value.
 
-### How Handles Work
+### How handles work
 
-When an entry is saved, a handle is automatically generated from the label and stored in the database:
-- "Red" → handle: "red"
-- "Primary Red" → handle: "primary-red"
-- "Sky Blue" → handle: "sky-blue"
+When an entry is saved, a handle is generated from the label (camelCase) and stored with the value:
 
-**This handle is stored silently and never exposed in your templates.**
+- "Red" → handle: `red`
+- "Primary Red" → handle: `primaryRed`
+- "Sky Blue" → handle: `skyBlue`
 
-### Safe Label Changes
+The handle is used internally for matching. It is available in GraphQL if you need it, but you'll usually only work with the label, colour, and class.
 
-**Option 1: Add explicit handles (Recommended)**
+### Handle priority
 
-Add a `handle` field to your config before changing labels:
+1. **Explicit `handle` in the config** is always used if present (allows intentional handle changes)
+2. **Existing handle stored with the value** is preserved for stability
+3. **Auto-generated from the label** on first save
 
-```php
-'palettes' => [
-    'Tailwind' => [
-        [
-            'handle' => 'red',        // Add this once - keeps it stable
-            'label' => 'Red',         // Can be changed freely after handle is set
-            'color' => [['color' => '#ef4444']]
-        ]
-    ]
-]
+For guaranteed stability, add explicit `handle` keys to your config entries (see the example above). If you rename a *handle* in your config, run `php craft resave/entries` afterwards so stored values are re-matched.
+
+## Searching
+
+As of 5.2.0, Colour Swatches values are indexed by Craft search. When the field is marked as searchable in its field layout, entries can be found by swatch label, handle, CSS class, or colour value:
+
+```twig
+{% set entries = craft.entries.search('red').all() %}
 ```
 
-**Workflow:**
-1. Add `handle` to your config entries
-2. Run `./craft resave/entries` once to store handles
-3. Now you can change `label` values without breaking existing entries
+## GraphQL
 
-**Option 2: Without explicit handles**
+Swatch fields resolve to a shared `ColourSwatches_SwatchData` type:
 
-If you don't add explicit handles, the system auto-generates them from labels. To change a label:
-
-1. Change the label in your config
-2. Run `./craft resave/entries` to update all entries
-
-### Handle Priority
-
-The system uses this priority for handles:
-
-1. **Explicit handle in config** → Always used if present (allows intentional handle changes)
-2. **Existing handle in database** → Preserved for stability
-3. **Auto-generated from label** → Created on first save
-
-This means you have full control: use auto-generation for simplicity, or add explicit handles when you need guaranteed stability.
-
-
-### GraphQL
-
-Colour Swatches comes with GraphQL support you can build a query as follows:
-
-```
+```graphql
 fieldName {
-        label
-        class
-        color
-      }
+    label
+    handle
+    class
+    color
+}
 ```
 
-which will give you the following result if you use the config file:
+which returns:
 
-```
+```json
 "fieldName": {
-          "label": "Black/White",
-          "class": "",
-          "color": [
-            "{\"color\":\"#000000\",\"background\":\"bg-black\"}",
-            "{\"color\":\"#ffffff\",\"text\":\"text-white\"}"
-          ]
-        },
+    "label": "Sunset",
+    "handle": "sunset",
+    "class": "bg-sunset",
+    "color": [
+        { "color": "#f59e0b" },
+        { "color": "#ef4444" }
+    ]
+}
 ```
 
-or in case of a single value added through the settings you will see:
+### GraphQL Mode
 
+Each field has a **GraphQL Mode** setting (shown when GraphQL is enabled) with two options:
+
+- **Full data** (default): returns the `ColourSwatches_SwatchData` object shown above
+- **Label only**: returns the label as a plain string, matching the pre-1.7 behaviour
+
+```graphql
+# with "Label only" mode
+fieldName  # "Sunset"
 ```
-"fieldName": {
-          "label": "Black",
-          "class": "",
-          "color": [
-            "#000000"
-          ]
-        },
-```
 
+### Upgrading GraphQL queries to 5.2.0
 
+Two breaking changes if you upgrade from an earlier version:
 
-Brought to you by [Craft Pulse](https://github.com/craftpulse)
+- The per-field-handle type names were replaced by the single shared `ColourSwatches_SwatchData` type. Update any inline fragments that referenced the old type names.
+- Colour values are no longer double-JSON-encoded. If your client code parsed the `color` strings manually, remove the extra parse step.
+
+---
+
+Brought to you by [CraftPulse](https://github.com/craftpulse)

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "craftpulse/craft-colour-swatches",
     "description": "Let clients choose from a predefined set of colours and utilise associated colour codes and class names in your templates.",
     "type": "craft-plugin",
+    "version": "5.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftpulse/craft-colour-swatches",
     "description": "Let clients choose from a predefined set of colours and utilise associated colour codes and class names in your templates.",
     "type": "craft-plugin",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     "config": {
         "allow-plugins": {
             "yiisoft/yii2-composer": true,
-            "craftcms/plugin-installer": true
+            "craftcms/plugin-installer": true,
+            "pestphp/pest-plugin": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,7 @@
         "developerUrl": "https://github.com/craftpulse",
         "documentationUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/README.md",
         "changelogUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/CHANGELOG.md",
-        "class": "percipiolondon\\colourswatches\\ColourSwatches",
-        "craftcms-claude-skills": "1.2.0"
+        "class": "percipiolondon\\colourswatches\\ColourSwatches"
     },
     "scripts": {
         "phpstan": "phpstan --memory-limit=1G",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "swatches"
     ],
     "support": {
-        "email": "support@craftpulse.com",
+        "email": "support@craft-pulse.com",
         "docs": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/README.md",
         "issues": "https://github.com/craftpulse/craft-colour-swatches/issues"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "swatches"
     ],
     "support": {
-        "email": "support@percipio.london",
-        "docs": "https://github.com/percipioglobal/craft-colour-swatches/blob/v4/README.md",
-        "issues": "https://github.com/percipioglobal/craft-colour-swatches/issues"
+        "email": "support@craftpulse.com",
+        "docs": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/README.md",
+        "issues": "https://github.com/craftpulse/craft-colour-swatches/issues"
     },
     "license": "MIT",
     "authors": [
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.2",
         "craftcms/cms": "^5.0.0"
     },
     "require-dev": {
@@ -48,9 +48,10 @@
         "description": "Adding custom selectable colour palettes, gradients, classes and more to your field types.",
         "developer": "craftpulse",
         "developerUrl": "https://github.com/craftpulse",
-        "documentationUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v4/README.md",
-        "changelogUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v4/CHANGELOG.md",
-        "class": "percipiolondon\\colourswatches\\ColourSwatches"
+        "documentationUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/README.md",
+        "changelogUrl": "https://github.com/craftpulse/craft-colour-swatches/blob/v5/CHANGELOG.md",
+        "class": "percipiolondon\\colourswatches\\ColourSwatches",
+        "craftcms-claude-skills": "1.2.0"
     },
     "scripts": {
         "phpstan": "phpstan --memory-limit=1G"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "craftpulse/craft-colour-swatches",
     "description": "Let clients choose from a predefined set of colours and utilise associated colour codes and class names in your templates.",
     "type": "craft-plugin",
-    "version": "5.3.0",
+    "version": "5.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,17 @@
     "require-dev": {
         "craftcms/cms": "^5.0.0",
         "craftcms/phpstan": "dev-main",
-        "craftcms/rector": "dev-main"
+        "craftcms/rector": "dev-main",
+        "pestphp/pest": "^3.0"
     },
     "autoload": {
         "psr-4": {
             "percipiolondon\\colourswatches\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "percipiolondon\\colourswatches\\tests\\": "tests/"
         }
     },
     "extra": {
@@ -54,7 +60,9 @@
         "craftcms-claude-skills": "1.2.0"
     },
     "scripts": {
-        "phpstan": "phpstan --memory-limit=1G"
+        "phpstan": "phpstan --memory-limit=1G",
+        "test": "pest",
+        "test:unit": "pest --group=unit"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "craftpulse/craft-colour-swatches",
     "description": "Let clients choose from a predefined set of colours and utilise associated colour codes and class names in your templates.",
     "type": "craft-plugin",
-    "version": "5.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,6 @@ parameters:
     level: 5
     paths:
         - src
+    ignoreErrors:
+        # The `recursive` Collection macro is registered at runtime in plugin init()
+        - '#Call to an undefined method Illuminate\\Support\\Collection.*::recursive\(\)#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/ColourSwatches.php
+++ b/src/ColourSwatches.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/ColourSwatches.php
+++ b/src/ColourSwatches.php
@@ -23,12 +23,12 @@ use yii\base\Event;
 /**
  * Class ColourSwatches.
  *
- * @author    Percipio Global Ltd.
- *
- * @since     1.0.0
  * @property Settings $settings
  *
  * @method Settings getSettings()
+ *
+ * @author CraftPulse
+ * @since 1.0.0
  */
 class ColourSwatches extends Plugin
 {
@@ -57,7 +57,7 @@ class ColourSwatches extends Plugin
     // =========================================================================
 
     /**
-     * init
+     * @inheritdoc
      */
     public function init(): void
     {
@@ -69,7 +69,7 @@ class ColourSwatches extends Plugin
         Event::on(
             Fields::class,
             Fields::EVENT_REGISTER_FIELD_TYPES,
-            function(RegisterComponentTypesEvent $event) {
+            static function(RegisterComponentTypesEvent $event) {
                 $event->types[] = ColourSwatchesField::class;
             }
         );
@@ -88,7 +88,7 @@ class ColourSwatches extends Plugin
     // =========================================================================
 
     /**
-     * @return Settings
+     * @inheritdoc
      */
     protected function createSettingsModel(): Settings
     {
@@ -118,6 +118,7 @@ class ColourSwatches extends Plugin
     {
         if (!Collection::hasMacro('recursive')) {
             Collection::macro('recursive', function () {
+                /** @var Collection $this */
                 return $this->map(function ($value) {
                     if (is_array($value) || is_object($value)) {
                         return collect($value)->recursive();

--- a/src/ColourSwatches.php
+++ b/src/ColourSwatches.php
@@ -15,6 +15,7 @@ use Craft;
 use craft\base\Plugin;
 use craft\events\RegisterComponentTypesEvent;
 use craft\services\Fields;
+use Illuminate\Support\Collection;
 use percipiolondon\colourswatches\fields\ColourSwatches as ColourSwatchesField;
 use percipiolondon\colourswatches\models\Settings;
 use yii\base\Event;
@@ -63,6 +64,8 @@ class ColourSwatches extends Plugin
         parent::init();
         self::$plugin = $this;
 
+        $this->_registerCollectionMacros();
+
         Event::on(
             Fields::class,
             Fields::EVENT_REGISTER_FIELD_TYPES,
@@ -81,6 +84,9 @@ class ColourSwatches extends Plugin
         );
     }
 
+    // Protected Methods
+    // =========================================================================
+
     /**
      * @return Settings
      */
@@ -98,5 +104,28 @@ class ColourSwatches extends Plugin
             'colour-swatches/_settings',
             ['settings' => $this->getSettings()]
         );
+    }
+
+    // Private Methods
+    // =========================================================================
+
+    /**
+     * Register Collection macros used by the ColourSwatches model.
+     *
+     * @return void
+     */
+    private function _registerCollectionMacros(): void
+    {
+        if (!Collection::hasMacro('recursive')) {
+            Collection::macro('recursive', function () {
+                return $this->map(function ($value) {
+                    if (is_array($value) || is_object($value)) {
+                        return collect($value)->recursive();
+                    }
+
+                    return $value;
+                });
+            });
+        }
     }
 }

--- a/src/ColourSwatches.php
+++ b/src/ColourSwatches.php
@@ -46,7 +46,7 @@ class ColourSwatches extends Plugin
     /**
      * @var string
      */
-    public string $schemaVersion = '1.4.3';
+    public string $schemaVersion = '1.5.0';
 
     /**
      * @var bool

--- a/src/assetbundles/colourswatchesfield/ColourSwatchesFieldAsset.php
+++ b/src/assetbundles/colourswatchesfield/ColourSwatchesFieldAsset.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/assetbundles/colourswatchesfield/ColourSwatchesFieldAsset.php
+++ b/src/assetbundles/colourswatchesfield/ColourSwatchesFieldAsset.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * color-swatches plugin for Craft CMS 3.x.
+ * colour-swatches plugin for Craft CMS 5.x.
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://percipio.london
+ * @link      https://craftpulse.com
  *
- * @copyright Copyright (c) 2020 Percipio Global Ltd.
+ * @copyright Copyright (c) 2024 CraftPulse.
  */
 
 namespace percipiolondon\colourswatches\assetbundles\colourswatchesfield;

--- a/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
+++ b/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
@@ -3,9 +3,9 @@
  *
  * ColourSwatches Field CSS
  *
- * @author    Percipio Global Ltd.
- * @copyright Copyright (c) 2020 Percipio Global Ltd.
- * @link      https://percipio.london
+ * @author    CraftPulse
+ * @copyright Copyright (c) 2024 CraftPulse.
+ * @link      https://craftpulse.com
  * @package   Colour Swatches
  * @since     1.0.0
  */

--- a/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
+++ b/src/assetbundles/colourswatchesfield/dist/css/ColourSwatches.css
@@ -5,7 +5,7 @@
  *
  * @author    CraftPulse
  * @copyright Copyright (c) 2024 CraftPulse.
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  * @package   Colour Swatches
  * @since     1.0.0
  */

--- a/src/config.php
+++ b/src/config.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * color-swatches plugin for Craft CMS 4.x.
+ * colour-swatches plugin for Craft CMS 5.x.
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://percipio.london
+ * @link      https://craftpulse.com
  *
- * @copyright Copyright (c) 2020 Percipio.London
+ * @copyright Copyright (c) 2024 CraftPulse.
  */
 
 /**

--- a/src/config.php
+++ b/src/config.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/config.php
+++ b/src/config.php
@@ -132,7 +132,7 @@ return [
                 'class' => null, // provide extra classes to go along with this palette
                 'color' => [
                     [
-                        'color' => '#a855f7',               // the colour shown in the fieldtype (required)
+                        'color' => '#ef4444',               // the colour shown in the fieldtype (required)
                         'background' => 'bg-red-500',
                         'backgroundHover' => 'hover:bg-red-700',
                         'text' => 'text-white',

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * colour-swatches plugin for Craft CMS 3.x.
+ * colour-swatches plugin for Craft CMS 5.x.
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://percipio.london
+ * @link      https://craftpulse.com
  *
- * @copyright Copyright (c) 2020 Percipio Global Ltd.
+ * @copyright Copyright (c) 2024 CraftPulse.
  */
 
 namespace percipiolondon\colourswatches\fields;

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -374,7 +374,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
             ->namespaceInputId($id);
 
         Craft::$app->getView()
-            ->registerJs("new ColourSelectInput('{$namespacedId}');");
+            ->registerJs("new ColourSelectInput(" . Json::encode($namespacedId) . ");");
 
         // Render the input template
         return Craft::$app->getView()
@@ -475,6 +475,6 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
                 }
             }
         }
-        return '<div class="color small static"><div class="color-preview" style="' . $style . '"></div></div>';
+        return '<div class="color small static"><div class="color-preview" style="' . Html::encode($style) . '"></div></div>';
     }
 }

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -110,12 +110,6 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
         return array_merge($rules, [['options', 'each', 'rule' => ['required']], ]);
     }
 
-    public function beforeSave(bool $isNew): bool
-    {
-        $this->options = $this->settings['options'] ?? [];
-        return parent::beforeSave($isNew);
-    }
-
     /**
      * @return array|string
      */
@@ -142,22 +136,14 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
         }
 
         if (is_null($value) || $value === '') {
-
-            // if useConfigFile is set, fetch the objects from that file
-            if ($this->useConfigFile) {
-                if (ColorSwatches::$plugin->settings->palettes[$this->palette] ?? false) {
-                    // if the palette with the value exists, return this as the settings palette
-                    $this->options = ColorSwatches::$plugin->settings->palettes[$this->palette];
-                } else {
-                    // if it doesn't exist, set it to the default colors
-                    $this->options = ColorSwatches::$plugin->settings->colors ?: [];
-                }
-            }
+            $resolvedOptions = $this->_resolveOptions();
 
             // if default is set --> return default
-            $default = array_filter($this->options, function($option) {return $option['default'] == 1;});
+            $default = array_filter($resolvedOptions, function($option) {
+                return !empty($option['default']);
+            });
 
-            if (is_array($default) && count($default) > 0) {
+            if (count($default) > 0) {
                 return new ColourSwatchesModel(Json::encode(array_values($default)[0]));
             }
 
@@ -186,23 +172,10 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
             ];
         }
 
-        $settingsPalette = $this->options;
+        $resolvedOptions = $this->_resolveOptions();
         $saveValue = null;
 
-        // if useConfigFile is set, fetch the objects from that file
-        if ($this->useConfigFile) {
-            if (ColorSwatches::$plugin->settings->palettes[$this->palette] ?? false) {
-                // if the palette with the value exists, return this as the settings palette
-                $settingsPalette = ColorSwatches::$plugin->settings->palettes[$this->palette];
-            } else {
-                // if it doesn't exist, set it to the default colors
-                $settingsPalette = ColorSwatches::$plugin->settings->colors ?: [];
-            }
-        }
-
-        $this->options = $settingsPalette;
-
-        foreach ($settingsPalette as $palette) {
+        foreach ($resolvedOptions as $palette) {
             $matched = false;
 
             // get or generate handle
@@ -210,7 +183,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
 
             // if handle is already saved, match by handle
             if ($value && !empty($value['handle'])) {
-                if($paletteHandle == $value['handle']) {
+                if ($paletteHandle === $value['handle']) {
                     $matched = true;
                 }
             } elseif ($value && ($palette['label'] === $value['label'])) {
@@ -241,17 +214,20 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
 
         // if nothing got set, use the default if that exists
         if (!$saveValue) {
+            $defaultLabel = $this->default;
 
-            if (is_null($this->default)) {
-                $default = array_filter($settingsPalette, function($option) {return $option['default'] == true;});
+            if (is_null($defaultLabel)) {
+                $default = array_filter($resolvedOptions, function($option) {
+                    return !empty($option['default']);
+                });
 
-                if (!is_null($default) && count($default) > 0) {
-                    $this->default = array_values($default)[0]['label'];
+                if (count($default) > 0) {
+                    $defaultLabel = array_values($default)[0]['label'];
                 }
             }
 
-            foreach ($settingsPalette as $palette) {
-                if (is_array($palette) && $palette['label'] === $this->default) {
+            foreach ($resolvedOptions as $palette) {
+                if (is_array($palette) && $palette['label'] === $defaultLabel) {
                     $saveValue = $palette;
                     $saveValue['handle'] = $palette['handle'] ?? $this->_generateHandle($palette['label']);
                 }
@@ -260,17 +236,41 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
 
         // if no default is defined and random is set, pick a random colour
         if (!$saveValue && $this->setRandom) {
-            $random = array_rand($settingsPalette, 1);
-            $saveValue = $settingsPalette[$random];
-            $saveValue['handle'] = $settingsPalette[$random]['handle'] ?? $this->_generateHandle($saveValue['label']);
+            $random = array_rand($resolvedOptions, 1);
+            $saveValue = $resolvedOptions[$random];
+            $saveValue['handle'] = $resolvedOptions[$random]['handle'] ?? $this->_generateHandle($saveValue['label']);
         }
 
         return $saveValue;
     }
 
+    // Private Methods
+    // =========================================================================
+
     /**
-     * Generate a stable handle from a label
-     * Handles are never exposed to users but allow for label changes
+     * Resolve the effective options for this field, using config file palettes
+     * when configured or falling back to inline options.
+     *
+     * @return array
+     */
+    private function _resolveOptions(): array
+    {
+        if ($this->useConfigFile) {
+            $settings = ColorSwatches::$plugin->settings;
+
+            if ($settings->palettes[$this->palette] ?? false) {
+                return $settings->palettes[$this->palette];
+            }
+
+            return $settings->colors ?: [];
+        }
+
+        return $this->options;
+    }
+
+    /**
+     * Generate a stable handle from a label.
+     * Handles are never exposed to users but allow for label changes.
      *
      * @param string $label
      * @return string
@@ -322,14 +322,6 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
             'allowReorder' => true,
             'allowDelete' => true,
         ];
-
-        $paletteOptions = [];
-        $paletteOptions[] = ['label' => 'Colors', 'value' => null, ];
-        foreach (array_keys(ColorSwatches::$plugin
-            ->settings
-            ->palettes) as $palette) {
-            $paletteOptions[] = ['label' => $palette, 'value' => $palette, ];
-        }
 
         $paletteOptions = [];
         $paletteOptions[] = ['label' => 'Colour config', 'value' => null, ];

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -75,7 +75,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
      * or just the label string.
      *
      * @var bool
-     * @since 5.3.0
+     * @since 5.2.0
      */
     public bool $fullGraphqlData = true;
 
@@ -296,7 +296,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
      * @return string
      *
      * @author CraftPulse
-     * @since 5.3.0
+     * @since 5.2.0
      */
     protected function searchKeywords(mixed $value, ElementInterface $element): string
     {

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -18,6 +18,7 @@ use craft\base\PreviewableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\TypeLoader;
+use craft\helpers\Cp;
 use craft\helpers\Html;
 use craft\helpers\Json;
 
@@ -68,6 +69,32 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
 
     /** @var int|string|null */
     public string|int|null $default = null;
+
+    /**
+     * Whether the GraphQL type should return full swatch data (label, color, class, handle)
+     * or just the label string.
+     *
+     * @var bool
+     * @since 5.3.0
+     */
+    public bool $fullGraphqlData = true;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($config = [])
+    {
+        // Convert graphqlMode select value to boolean property
+        if (isset($config['graphqlMode'])) {
+            $config['fullGraphqlData'] = $config['graphqlMode'] === 'full';
+            unset($config['graphqlMode']);
+        }
+
+        parent::__construct($config);
+    }
 
     // Static Methods
     // =========================================================================
@@ -332,7 +359,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
         }
 
         // Render the settings template
-        return Craft::$app->getView()
+        $html = Craft::$app->getView()
             ->renderTemplate('colour-swatches/settings',
                 [
                     'field' => $this,
@@ -342,6 +369,23 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
                     'palettes' => ColorSwatches::$plugin->settings->palettes,
                 ]
             );
+
+        if (Craft::$app->getConfig()->getGeneral()->enableGql) {
+            $html .= Html::tag('hr') .
+                Cp::selectFieldHtml([
+                    'label' => Craft::t('colour-swatches', 'GraphQL Mode'),
+                    'id' => 'graphql-mode',
+                    'name' => 'graphqlMode',
+                    'instructions' => Craft::t('colour-swatches', 'Controls whether GraphQL returns just the label string or the full swatch data object.'),
+                    'options' => [
+                        ['label' => Craft::t('colour-swatches', 'Full data'), 'value' => 'full'],
+                        ['label' => Craft::t('colour-swatches', 'Label only'), 'value' => 'label'],
+                    ],
+                    'value' => $this->fullGraphqlData ? 'full' : 'label',
+                ]);
+        }
+
+        return $html;
     }
 
     /**
@@ -384,11 +428,15 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
     }
 
     /**
-     * @return Type|array
+     * @inheritdoc
      */
     public function getContentGqlType(): Type|array
     {
-        $typeName = $this->handle;
+        if (!$this->fullGraphqlData) {
+            return parent::getContentGqlType();
+        }
+
+        $typeName = 'ColourSwatches_SwatchData';
 
         $swatchType = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new ObjectType([
             'name' => $typeName,
@@ -396,34 +444,40 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
                 'label' => [
                     'name' => 'label',
                     'type' => Type::string(),
-                    'description' => 'The colour label'
+                    'description' => 'The colour label',
+                ],
+                'handle' => [
+                    'name' => 'handle',
+                    'type' => Type::string(),
+                    'description' => 'The stable colour handle',
                 ],
                 'class' => [
                     'name' => 'class',
                     'type' => Type::string(),
-                    'description' => 'The parent class'
+                    'description' => 'The CSS class',
                 ],
                 'color' => [
                     'name' => 'color',
                     'type' => Type::listOf(Type::string()),
-                    'description' => 'Our swatch colors',
+                    'description' => 'The swatch colour values',
                     'resolve' => function($source, array $arguments, $context, ResolveInfo $resolveInfo) {
                         $fieldName = $resolveInfo->fieldName;
                         $data = $source[$fieldName];
-                        $colors = [];
 
-                        if(is_iterable($data)) {
+                        if (is_iterable($data)) {
+                            $colors = [];
                             foreach ($data as $color) {
-                                $colors[] = Json::encode($color);
+                                // Config-file colours are objects with a 'color' key
+                                $colors[] = is_array($color) ? ($color['color'] ?? '') : (string)$color;
                             }
-                        } else {
-                            $colors[] = $data;
+                            return $colors;
                         }
 
-                        return $colors;
-                    }
-                ]
-            ]
+                        // Single colour string — may be comma-separated
+                        return is_string($data) ? explode(',', $data) : [$data];
+                    },
+                ],
+            ],
         ]));
 
         TypeLoader::registerType($typeName, static function() use ($swatchType) {

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -189,14 +189,21 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
      */
     public function serializeValue(mixed $value, ?ElementInterface $element = null): mixed
     {
+        // Craft normalizes before serializing, so the value is usually a model.
+        // Convert it to an array and run it through the option matching below,
+        // so settings-defined class/color/default enrich the stored value (the
+        // CP input only posts label, color, and handle).
+        $fromModel = false;
+
         if ($value instanceof ColourSwatchesModel) {
-            return [
+            $value = [
                 'handle' => $value->handle,
                 'label' => $value->label,
                 'color' => $value->color,
                 'class' => $value->class,
                 'default' => $value->default,
             ];
+            $fromModel = true;
         }
 
         $resolvedOptions = $this->_resolveOptions();
@@ -237,6 +244,12 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
                 $saveValue['class'] = $palette['class'];
                 $saveValue['default'] = $palette['default'] ?? false;
             }
+        }
+
+        // preserve model values that no longer match any option (e.g. the
+        // option was removed from the config) instead of swapping to default
+        if (!$saveValue && $fromModel && !empty($value['label'])) {
+            return $value;
         }
 
         // if nothing got set, use the default if that exists

--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -271,6 +271,43 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
         return $saveValue;
     }
 
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * Returns the search keywords for this field's value, so entries can be
+     * found by swatch label, handle, CSS class, or colour value.
+     *
+     * @param mixed $value
+     * @param ElementInterface $element
+     * @return string
+     *
+     * @author CraftPulse
+     * @since 5.3.0
+     */
+    protected function searchKeywords(mixed $value, ElementInterface $element): string
+    {
+        if (!$value instanceof ColourSwatchesModel) {
+            return '';
+        }
+
+        $keywords = [$value->label, $value->handle, $value->class];
+
+        if (is_string($value->color)) {
+            $keywords[] = $value->color;
+        } elseif (is_array($value->color)) {
+            foreach ($value->color as $color) {
+                if (is_array($color)) {
+                    $keywords[] = $color['color'] ?? null;
+                } elseif (is_string($color)) {
+                    $keywords[] = $color;
+                }
+            }
+        }
+
+        return implode(' ', array_filter($keywords));
+    }
+
     // Private Methods
     // =========================================================================
 
@@ -517,7 +554,7 @@ class ColourSwatches extends Field implements PreviewableFieldInterface, Sortabl
                     // if we're using the CP values
                 } else {
                     $color = $value->color;
-                    $style = strpos($color, ',') ? "background: linear-gradient(to bottom right, $color);" : "background-color:$color";
+                    $style = str_contains($color, ',') ? "background: linear-gradient(to bottom right, $color);" : "background-color:$color";
                 }
             }
         }

--- a/src/migrations/m200911_142127_update_namespace.php
+++ b/src/migrations/m200911_142127_update_namespace.php
@@ -5,7 +5,11 @@ namespace percipiolondon\colourswatches\migrations;
 use craft\db\Migration;
 
 /**
- * m200911_142127_update_namespace migration.
+ * Updates field type class references from the pre-1.x `percipioglobal` namespace
+ * to `percipioglobal\colourswatches`.
+ *
+ * @author CraftPulse
+ * @since 1.3.0
  */
 class m200911_142127_update_namespace extends Migration
 {

--- a/src/migrations/m220503_104406_namespace_migration.php
+++ b/src/migrations/m220503_104406_namespace_migration.php
@@ -5,11 +5,15 @@ namespace percipiolondon\colourswatches\migrations;
 use craft\db\Migration;
 
 /**
- * m220503_104406_namespace_migration migration.
+ * Updates field type class references from the `percipioglobal` namespace
+ * to `percipiolondon\colourswatches`.
  *
  * @deprecated Has a parameter binding bug (missing colon prefix on params key).
  *             Fixed by m220523_152700_namespace_migration_fix. Must not be modified
  *             as it has already been applied to existing installations.
+ *
+ * @author CraftPulse
+ * @since 3.0.0
  */
 class m220503_104406_namespace_migration extends Migration
 {
@@ -40,7 +44,7 @@ class m220503_104406_namespace_migration extends Migration
      */
     public function safeDown(): bool
     {
-        echo "m200911_142127_update_namespace cannot be reverted.\n";
+        echo "m220503_104406_namespace_migration cannot be reverted.\n";
         return false;
     }
 }

--- a/src/migrations/m220503_104406_namespace_migration.php
+++ b/src/migrations/m220503_104406_namespace_migration.php
@@ -5,7 +5,11 @@ namespace percipiolondon\colourswatches\migrations;
 use craft\db\Migration;
 
 /**
- * m200911_142127_update_namespace migration.
+ * m220503_104406_namespace_migration migration.
+ *
+ * @deprecated Has a parameter binding bug (missing colon prefix on params key).
+ *             Fixed by m220523_152700_namespace_migration_fix. Must not be modified
+ *             as it has already been applied to existing installations.
  */
 class m220503_104406_namespace_migration extends Migration
 {

--- a/src/migrations/m220523_152700_namespace_migration_fix.php
+++ b/src/migrations/m220523_152700_namespace_migration_fix.php
@@ -5,7 +5,11 @@ namespace percipiolondon\colourswatches\migrations;
 use craft\db\Migration;
 
 /**
- * m220523_152700_namespace_migration_fix migration.
+ * Re-runs the `percipioglobal` to `percipiolondon\colourswatches` namespace update
+ * with correct parameter binding, fixing m220503_104406_namespace_migration.
+ *
+ * @author CraftPulse
+ * @since 3.0.1
  */
 class m220523_152700_namespace_migration_fix extends Migration
 {

--- a/src/migrations/m240402_112820_namespace.php
+++ b/src/migrations/m240402_112820_namespace.php
@@ -2,7 +2,6 @@
 
 namespace percipiolondon\colourswatches\migrations;
 
-use Craft;
 use craft\db\Migration;
 
 /**

--- a/src/migrations/m240402_112820_namespace.php
+++ b/src/migrations/m240402_112820_namespace.php
@@ -5,7 +5,11 @@ namespace percipiolondon\colourswatches\migrations;
 use craft\db\Migration;
 
 /**
- * m240402_112820_namespace migration.
+ * Ensures any remaining `percipioglobal` field type class references are updated
+ * to `percipiolondon\colourswatches` for Craft 5 installs.
+ *
+ * @author CraftPulse
+ * @since 5.0.0
  */
 class m240402_112820_namespace extends Migration
 {

--- a/src/migrations/m260716_120000_backfill_swatch_handles.php
+++ b/src/migrations/m260716_120000_backfill_swatch_handles.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace percipiolondon\colourswatches\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\helpers\Queue;
+use craft\queue\jobs\ResaveElements;
+use percipiolondon\colourswatches\fields\ColourSwatches as ColourSwatchesField;
+
+/**
+ * Backfills stable handles on stored swatch values.
+ *
+ * Values saved before 5.2.0 only contain label, colour, and class. Resaving an
+ * element runs the value through serializeValue(), which matches it against the
+ * field's option definitions and writes the stable handle (plus search
+ * keywords). This migration queues a batched resave job for every element type
+ * whose field layout contains a Colour Swatches field.
+ *
+ * @author CraftPulse
+ * @since 5.2.0
+ */
+class m260716_120000_backfill_swatch_handles extends Migration
+{
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $elementTypes = [];
+
+        foreach (Craft::$app->getFields()->getAllLayouts() as $layout) {
+            foreach ($layout->getCustomFields() as $field) {
+                if ($field instanceof ColourSwatchesField) {
+                    $elementTypes[$layout->type] = true;
+                    break;
+                }
+            }
+        }
+
+        foreach (array_keys($elementTypes) as $elementType) {
+            echo "    > queueing resave job for {$elementType} elements ...\n";
+
+            Queue::push(new ResaveElements([
+                'elementType' => $elementType,
+                'criteria' => ['status' => null],
+                'updateSearchIndex' => true,
+            ]));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m260716_120000_backfill_swatch_handles cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/ColourSwatches.php
+++ b/src/models/ColourSwatches.php
@@ -2,7 +2,6 @@
 
 namespace percipiolondon\colourswatches\models;
 
-use Craft;
 use craft\base\Model;
 use craft\helpers\Json;
 use Illuminate\Support\Collection;
@@ -50,7 +49,7 @@ class ColourSwatches extends Model
     {
         parent::__construct();
 
-        if ($this->validateJson($value)) {
+        if ($value !== null && Json::isJsonObject($value)) {
             $colorData = Json::decode($value);
 
             if (!empty($colorData['label'])) {
@@ -61,44 +60,14 @@ class ColourSwatches extends Model
                 $this->class = $colorData['class'] ?? '';
             }
         }
-
-        if (!Collection::hasMacro('recursive')) {
-            Collection::macro('recursive', function () {
-                return $this->map(function ($value) {
-                    if (is_array($value) || is_object($value)) {
-                        return collect($value)->recursive();
-                    }
-
-                    return $value;
-                });
-            });
-        }
     }
 
     /**
-     * @param string|null $value
-     * @return bool
+     * @return Collection
      */
-    public function validateJson(?string $value): bool
+    public function collection(): Collection
     {
-        if (Json::isJsonObject($value)) {
-            $json = Json::decode($value);
-            return $json && $value != $json;
-        }
-
-        return false;
-    }
-
-    /**
-     * @return Collection|null
-     */
-    public function collection(): ?Collection
-    {
-        if ($this) {
-            return collect($this['color'])->recursive();
-        }
-
-        return null;
+        return collect($this->color ?? [])->recursive();
     }
 
     /**

--- a/src/models/ColourSwatches.php
+++ b/src/models/ColourSwatches.php
@@ -28,7 +28,7 @@ class ColourSwatches extends Model
 
     /**
      * @var string|null Silent stable identifier
-     * @since 5.3.0
+     * @since 5.2.0
      */
     public ?string $handle = null;
 
@@ -102,7 +102,7 @@ class ColourSwatches extends Model
      * Returns the colour value(s).
      *
      * @return array|string|null
-     * @deprecated in 5.3.0. Access the `$color` property directly instead. Will be removed in 6.0.0.
+     * @deprecated in 5.2.0. Access the `$color` property directly instead. Will be removed in 6.0.0.
      */
     public function colors(): mixed
     {
@@ -113,7 +113,7 @@ class ColourSwatches extends Model
      * Returns the swatch label.
      *
      * @return string
-     * @deprecated in 5.3.0. Access the `$label` property directly instead. Will be removed in 6.0.0.
+     * @deprecated in 5.2.0. Access the `$label` property directly instead. Will be removed in 6.0.0.
      */
     public function labels(): mixed
     {
@@ -124,7 +124,7 @@ class ColourSwatches extends Model
      * Returns whether this swatch is the field default.
      *
      * @return bool|null
-     * @deprecated in 5.3.0. Access the `$default` property directly instead. Will be removed in 6.0.0.
+     * @deprecated in 5.2.0. Access the `$default` property directly instead. Will be removed in 6.0.0.
      */
     public function default(): mixed
     {
@@ -135,7 +135,7 @@ class ColourSwatches extends Model
      * Returns the CSS class(es) associated with this swatch.
      *
      * @return string|null
-     * @deprecated in 5.3.0. Access the `$class` property directly instead. Will be removed in 6.0.0.
+     * @deprecated in 5.2.0. Access the `$class` property directly instead. Will be removed in 6.0.0.
      */
     public function class(): mixed
     {

--- a/src/models/ColourSwatches.php
+++ b/src/models/ColourSwatches.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * colour-swatches plugin for Craft CMS 5.x.
+ *
+ * Let clients choose from a predefined set of colours.
+ *
+ * @link      https://craftpulse.com
+ *
+ * @copyright Copyright (c) 2024 CraftPulse.
+ */
 
 namespace percipiolondon\colourswatches\models;
 
@@ -7,12 +16,16 @@ use craft\helpers\Json;
 use Illuminate\Support\Collection;
 
 /**
- * Class ColourSwatches
+ * Colour swatch field value model.
  *
- * @package percipiolondon\colourswatches\models
+ * @author CraftPulse
+ * @since 1.0.0
  */
 class ColourSwatches extends Model
 {
+    // Public Properties
+    // =========================================================================
+
     /**
      * @var string|null Silent stable identifier
      * @since 5.2.0
@@ -20,25 +33,27 @@ class ColourSwatches extends Model
     public ?string $handle = null;
 
     /**
-     * @var string
+     * @var string The human-readable swatch label
      */
     public string $label = '';
 
     /**
-     * @var array|string|null
+     * @var array|string|null The colour value(s), either a single CSS colour string or an array of colour definitions
      */
     public array|string|null $color = null;
 
     /**
-     * @var bool|null
+     * @var bool|null Whether this swatch is the field default
      */
-    public bool|null $default = false;
+    public ?bool $default = false;
 
     /**
-     * @var string
+     * @var string|null Extra CSS class(es) associated with this swatch
      */
-    public string|null $class = '';
+    public ?string $class = '';
 
+    // Public Methods
+    // =========================================================================
 
     /**
      * ColourSwatches constructor.
@@ -63,7 +78,12 @@ class ColourSwatches extends Model
     }
 
     /**
+     * Returns the colour value(s) as a recursive Collection.
+     *
      * @return Collection
+     *
+     * @author CraftPulse
+     * @since 5.1.0
      */
     public function collection(): Collection
     {
@@ -79,7 +99,10 @@ class ColourSwatches extends Model
     }
 
     /**
-     * @return mixed
+     * Returns the colour value(s).
+     *
+     * @return array|string|null
+     * @deprecated in 5.3.0. Access the `$color` property directly instead. Will be removed in 6.0.0.
      */
     public function colors(): mixed
     {
@@ -87,7 +110,10 @@ class ColourSwatches extends Model
     }
 
     /**
-     * @return mixed
+     * Returns the swatch label.
+     *
+     * @return string
+     * @deprecated in 5.3.0. Access the `$label` property directly instead. Will be removed in 6.0.0.
      */
     public function labels(): mixed
     {
@@ -95,7 +121,10 @@ class ColourSwatches extends Model
     }
 
     /**
-     * @return mixed
+     * Returns whether this swatch is the field default.
+     *
+     * @return bool|null
+     * @deprecated in 5.3.0. Access the `$default` property directly instead. Will be removed in 6.0.0.
      */
     public function default(): mixed
     {
@@ -103,10 +132,28 @@ class ColourSwatches extends Model
     }
 
     /**
-     * @return mixed
+     * Returns the CSS class(es) associated with this swatch.
+     *
+     * @return string|null
+     * @deprecated in 5.3.0. Access the `$class` property directly instead. Will be removed in 6.0.0.
      */
     public function class(): mixed
     {
         return $this->class;
+    }
+
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    protected function defineRules(): array
+    {
+        return array_merge(parent::defineRules(), [
+            [['label', 'handle', 'class'], 'string'],
+            [['default'], 'boolean'],
+            [['color'], 'safe'],
+        ]);
     }
 }

--- a/src/models/ColourSwatches.php
+++ b/src/models/ColourSwatches.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/models/ColourSwatches.php
+++ b/src/models/ColourSwatches.php
@@ -28,7 +28,7 @@ class ColourSwatches extends Model
 
     /**
      * @var string|null Silent stable identifier
-     * @since 5.2.0
+     * @since 5.3.0
      */
     public ?string $handle = null;
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * colour-swatches plugin for Craft CMS 5.x.
+ *
+ * Let clients choose from a predefined set of colours.
+ *
+ * @link      https://craftpulse.com
+ *
+ * @copyright Copyright (c) 2024 CraftPulse.
+ */
 
 namespace percipiolondon\colourswatches\models;
 
@@ -6,32 +15,40 @@ use Craft;
 use craft\base\Model;
 
 /**
- * Class Settings
+ * Plugin settings model.
  *
- * @package percipiolondon\colourswatches\models
+ * @author CraftPulse
+ * @since 1.0.0
  */
 class Settings extends Model
 {
+    // Public Properties
+    // =========================================================================
+
     /**
-     * @var array
+     * @var array The default colour definitions available to fields
      */
     public array $colors = [];
+
     /**
-     * @var array
+     * @var array Named colour palettes available to fields
      */
     public array $palettes = [];
+
     /**
-     * @var array|null
+     * @var array|null The default swatch definition
      */
     public ?array $default = null;
 
+    // Protected Methods
+    // =========================================================================
+
     /**
-     * @return array[]
+     * @inheritdoc
      */
     protected function defineRules(): array
     {
         return [
-//            [['colors', 'palettes'], 'required'],
             [['colors', 'palettes'], function ($attribute, $params) {
                 if (!is_array($this->colors)) {
                     $this->addError('colors', Craft::t('colour-swatches', 'colors is not array!'));
@@ -54,7 +71,7 @@ class Settings extends Model
                     }
                 }
                 return $palettes;
-            }]
+            }],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -7,7 +7,7 @@
  *
  * @author    CraftPulse
  * @copyright Copyright (c) 2024 CraftPulse.
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  * @package   Colour Swatches
  * @since     4.3.0
  */

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -5,9 +5,9 @@
  *
  * ColourSwatches Settings
  *
- * @author    Percipio Global Ltd.
- * @copyright Copyright (c) 2023 Percipio Global Ltd.
- * @link      https://percipio.london
+ * @author    CraftPulse
+ * @copyright Copyright (c) 2024 CraftPulse.
+ * @link      https://craftpulse.com
  * @package   Colour Swatches
  * @since     4.3.0
  */

--- a/src/templates/colourOption.twig
+++ b/src/templates/colourOption.twig
@@ -44,7 +44,7 @@
                 --color: linear-gradient(to bottom right, {% for color in colours %}{{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index0 }}%, {{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
         {% endswitch -%}
     {% endset %}
-    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
+    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
         {# <span>&hellip;</span> #}
     </button>
 {% else %}
@@ -67,7 +67,7 @@
             --color: linear-gradient(to bottom right, {% for colour in colours %}{{ colour }} {{ percentage * loop.index0 }}%, {{ colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
         {% endswitch %}
     {% endset %}
-    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
+    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
         {#        <span>{{ option.label }}</span>#}
     </button>
 {% endif %}

--- a/src/templates/colourOption.twig
+++ b/src/templates/colourOption.twig
@@ -44,14 +44,13 @@
                 --color: linear-gradient(to bottom right, {% for color in colours %}{{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index0 }}%, {{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
         {% endswitch -%}
     {% endset %}
-    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
-        {# <span>&hellip;</span> #}
-    </button>
+    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}"></button>
 {% else %}
     {# option.color is a string #}
     {% set value = {
         label: option.label,
         color: colours,
+        handle: optionHandle,
     } %}
     {% if ';' in value.color %}
         {% set colours = value.color | split(';') %}
@@ -67,7 +66,5 @@
             --color: linear-gradient(to bottom right, {% for colour in colours %}{{ colour }} {{ percentage * loop.index0 }}%, {{ colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
         {% endswitch %}
     {% endset %}
-    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
-        {#        <span>{{ option.label }}</span>#}
-    </button>
+    <button type="button" title="{{ option.label }}" aria-label="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}"></button>
 {% endif %}

--- a/src/templates/colourOption.twig
+++ b/src/templates/colourOption.twig
@@ -35,15 +35,16 @@
         color: colours,
         handle: optionHandle,
     } %}
-    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="
-    {%- switch colours|length %}
-        {% case 1 %}
-            --color: {{ value.color[0].color is defined ? value.color[0].color : value.color[0].colour |parseRefs|raw }};
-        {% default %}
-            {% set percentage = 100 / colours|length %}
-            --color: linear-gradient(to bottom right, {% for color in colours %}{{ color.color is defined ? color.color : color.colour |parseRefs|raw }} {{ percentage * loop.index0 }}%, {{ color.color is defined ? color.color : color.colour |parseRefs|raw }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
-    {% endswitch -%}
-        ">
+    {% set colourStyle %}
+        {%- switch colours|length %}
+            {% case 1 %}
+                --color: {{ value.color[0].color is defined ? value.color[0].color : value.color[0].colour }};
+            {% default %}
+                {% set percentage = 100 / colours|length %}
+                --color: linear-gradient(to bottom right, {% for color in colours %}{{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index0 }}%, {{ color.color is defined ? color.color : color.colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
+        {% endswitch -%}
+    {% endset %}
+    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
         {# <span>&hellip;</span> #}
     </button>
 {% else %}
@@ -57,15 +58,16 @@
     {% else %}
         {% set colours = value.color | split(',') %}
     {% endif %}
-    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="
-    {% switch colours | length %}
-    {% case 1 %}
-        --color: {{ value.color|parseRefs|raw }};
-    {% default %}
-    {% set percentage = 100 / colours | length %}
-        --color: linear-gradient(to bottom right, {% for colour in colours %}{{ colour|parseRefs|raw }} {{ percentage * loop.index0 }}%, {{ colour|parseRefs|raw }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
-    {% endswitch %}
-        ">
+    {% set colourStyle %}
+        {% switch colours | length %}
+        {% case 1 %}
+            --color: {{ value.color }};
+        {% default %}
+            {% set percentage = 100 / colours | length %}
+            --color: linear-gradient(to bottom right, {% for colour in colours %}{{ colour }} {{ percentage * loop.index0 }}%, {{ colour }} {{ percentage * loop.index }}%{% if not loop.last %},{% endif %}{% endfor %});
+        {% endswitch %}
+    {% endset %}
+    <button type="button" title="{{ option.label }}" data-value="{{ value | json_encode }}" class="option {% if isActive %} button-active{% endif %}" style="{{ colourStyle|e('html_attr') }}">
         {#        <span>{{ option.label }}</span>#}
     </button>
 {% endif %}

--- a/src/templates/input.twig
+++ b/src/templates/input.twig
@@ -24,7 +24,7 @@
 
         {# Set the default value with handle #}
         {% if option.default %}
-            {% set optionHandle = option.handle ?? (option.label|kebab) %}
+            {% set optionHandle = option.handle ?? (option.label|camel) %}
             {% set value = {
                 label: option.label,
                 color: option.color is defined ? option.color : option.colour,
@@ -56,7 +56,7 @@
 </div>
 
 {{ forms.hidden({
-    id: id ~ namespacedId,
+    id: id,
     name: name,
     value: fieldValue,
     class: 'color-swatches-input'})

--- a/src/translations/en/colour-swatches.php
+++ b/src/translations/en/colour-swatches.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * color-swatches plugin for Craft CMS 3.x.
+ * colour-swatches plugin for Craft CMS 5.x.
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://percipio.london
+ * @link      https://craftpulse.com
  *
- * @copyright Copyright (c) 2020 Percipio Global Ltd.
+ * @copyright Copyright (c) 2024 CraftPulse.
  */
 
 /**
- * @author    Percipio Global Ltd.
+ * @author    CraftPulse
  *
  * @since     1.0.0
  */

--- a/src/translations/en/colour-swatches.php
+++ b/src/translations/en/colour-swatches.php
@@ -4,7 +4,7 @@
  *
  * Let clients choose from a predefined set of colours.
  *
- * @link      https://craftpulse.com
+ * @link      https://craft-pulse.com
  *
  * @copyright Copyright (c) 2024 CraftPulse.
  */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,4 @@
+<?php
+
+uses(\percipiolondon\colourswatches\tests\TestCase::class)->in('Unit');
+uses()->group('unit')->in('Unit');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace percipiolondon\colourswatches\tests;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+/**
+ * Base test case for unit tests.
+ *
+ * Registers Collection macros that are normally registered in plugin init().
+ */
+class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Register the recursive Collection macro (normally done in plugin init)
+        if (!Collection::hasMacro('recursive')) {
+            Collection::macro('recursive', function () {
+                return $this->map(function ($value) {
+                    if (is_array($value) || is_object($value)) {
+                        return collect($value)->recursive();
+                    }
+
+                    return $value;
+                });
+            });
+        }
+    }
+}

--- a/tests/Unit/Fields/ColourSwatchesConstructorTest.php
+++ b/tests/Unit/Fields/ColourSwatchesConstructorTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use percipiolondon\colourswatches\fields\ColourSwatches;
+
+// =========================================================================
+// graphqlMode -> fullGraphqlData conversion
+// =========================================================================
+
+it('converts graphqlMode "full" to fullGraphqlData true', function () {
+    $field = new ColourSwatches(['graphqlMode' => 'full']);
+
+    expect($field->fullGraphqlData)->toBeTrue();
+});
+
+it('converts graphqlMode "label" to fullGraphqlData false', function () {
+    $field = new ColourSwatches(['graphqlMode' => 'label']);
+
+    expect($field->fullGraphqlData)->toBeFalse();
+});
+
+it('defaults fullGraphqlData to true when not set', function () {
+    $field = new ColourSwatches();
+
+    expect($field->fullGraphqlData)->toBeTrue();
+});
+
+it('respects explicit fullGraphqlData config', function () {
+    $field = new ColourSwatches(['fullGraphqlData' => false]);
+
+    expect($field->fullGraphqlData)->toBeFalse();
+});
+
+// =========================================================================
+// serializeValue with ColourSwatchesModel
+// =========================================================================
+
+it('serializes a ColourSwatchesModel to array', function () {
+    $model = new \percipiolondon\colourswatches\models\ColourSwatches(
+        \craft\helpers\Json::encode([
+            'handle' => 'red',
+            'label' => 'Red',
+            'color' => '#ef4444',
+            'class' => 'bg-red-500',
+            'default' => true,
+        ])
+    );
+
+    $field = new ColourSwatches();
+    $result = $field->serializeValue($model);
+
+    expect($result)->toBeArray()
+        ->and($result['handle'])->toBe('red')
+        ->and($result['label'])->toBe('Red')
+        ->and($result['color'])->toBe('#ef4444')
+        ->and($result['class'])->toBe('bg-red-500')
+        ->and($result['default'])->toBeTrue();
+});
+
+// =========================================================================
+// serializeValue does NOT mutate field state (H-1 fix)
+// =========================================================================
+
+it('does not mutate $options during serialization', function () {
+    $options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false, 'handle' => 'red'],
+        ['label' => 'Blue', 'color' => '#00f', 'class' => '', 'default' => true, 'handle' => 'blue'],
+    ];
+
+    $field = new ColourSwatches();
+    $field->options = $options;
+
+    $value = ['label' => 'Red', 'handle' => 'red'];
+    $field->serializeValue($value);
+
+    // options should remain unchanged after serialization
+    expect($field->options)->toBe($options);
+});
+
+it('does not mutate $default during serialization', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => true, 'handle' => 'red'],
+    ];
+    $field->default = null;
+
+    // Serialize with an unmatched value to trigger default resolution
+    $field->serializeValue(['label' => 'NonExistent', 'handle' => 'nonExistent']);
+
+    // $default should remain null — not mutated to 'Red'
+    expect($field->default)->toBeNull();
+});
+
+// =========================================================================
+// serializeValue handle matching
+// =========================================================================
+
+it('matches by handle first (preferred)', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Old Label', 'color' => '#f00', 'class' => 'text-red', 'default' => false, 'handle' => 'red'],
+    ];
+
+    $value = ['label' => 'Different Label', 'handle' => 'red'];
+    $result = $field->serializeValue($value);
+
+    // Should match by handle even though labels differ (label rename scenario)
+    expect($result['handle'])->toBe('red')
+        ->and($result['label'])->toBe('Old Label')
+        ->and($result['color'])->toBe('#f00');
+});
+
+it('falls back to label matching when no handle', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false],
+    ];
+
+    $value = ['label' => 'Red'];
+    $result = $field->serializeValue($value);
+
+    expect($result['label'])->toBe('Red')
+        ->and($result['color'])->toBe('#f00');
+});
+
+it('generates handle when neither config nor value has one', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Light Blue', 'color' => '#93c5fd', 'class' => '', 'default' => false],
+    ];
+
+    $value = ['label' => 'Light Blue'];
+    $result = $field->serializeValue($value);
+
+    // StringHelper::toCamelCase('Light Blue') = 'lightBlue'
+    expect($result['handle'])->toBe('lightBlue');
+});
+
+it('prefers config handle over generated handle', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false, 'handle' => 'brandRed'],
+    ];
+
+    $value = ['label' => 'Red', 'handle' => 'brandRed'];
+    $result = $field->serializeValue($value);
+
+    expect($result['handle'])->toBe('brandRed');
+});
+
+// =========================================================================
+// serializeValue default resolution
+// =========================================================================
+
+it('uses default option when no match found', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => true, 'handle' => 'red'],
+        ['label' => 'Blue', 'color' => '#00f', 'class' => '', 'default' => false, 'handle' => 'blue'],
+    ];
+
+    $result = $field->serializeValue(['label' => 'NonExistent', 'handle' => 'nonExistent']);
+
+    expect($result['label'])->toBe('Red')
+        ->and($result['handle'])->toBe('red');
+});
+
+it('returns null when no match and no default', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false, 'handle' => 'red'],
+    ];
+
+    $result = $field->serializeValue(['label' => 'NonExistent', 'handle' => 'nonExistent']);
+
+    expect($result)->toBeNull();
+});
+
+// =========================================================================
+// normalizeValue
+// =========================================================================
+
+it('returns existing ColourSwatchesModel as-is', function () {
+    $model = new \percipiolondon\colourswatches\models\ColourSwatches(
+        \craft\helpers\Json::encode(['label' => 'Red', 'color' => '#f00'])
+    );
+
+    $field = new ColourSwatches();
+    $result = $field->normalizeValue($model);
+
+    expect($result)->toBe($model);
+});
+
+it('normalizes JSON string to ColourSwatchesModel', function () {
+    $json = \craft\helpers\Json::encode(['label' => 'Red', 'color' => '#f00', 'handle' => 'red']);
+
+    $field = new ColourSwatches();
+    $result = $field->normalizeValue($json);
+
+    expect($result)->toBeInstanceOf(\percipiolondon\colourswatches\models\ColourSwatches::class)
+        ->and($result->label)->toBe('Red')
+        ->and($result->handle)->toBe('red');
+});
+
+it('normalizes array to ColourSwatchesModel (Vizy compat)', function () {
+    $array = ['label' => 'Red', 'color' => '#f00', 'handle' => 'red'];
+
+    $field = new ColourSwatches();
+    $result = $field->normalizeValue($array);
+
+    expect($result)->toBeInstanceOf(\percipiolondon\colourswatches\models\ColourSwatches::class)
+        ->and($result->label)->toBe('Red');
+});
+
+it('returns null for empty value with no default', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false],
+    ];
+
+    expect($field->normalizeValue(null))->toBeNull()
+        ->and($field->normalizeValue(''))->toBeNull();
+});
+
+it('returns default model for empty value when default exists', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => false],
+        ['label' => 'Blue', 'color' => '#00f', 'class' => '', 'default' => true],
+    ];
+
+    $result = $field->normalizeValue(null);
+
+    expect($result)->toBeInstanceOf(\percipiolondon\colourswatches\models\ColourSwatches::class)
+        ->and($result->label)->toBe('Blue');
+});
+
+// =========================================================================
+// Default detection uses !empty() not == 1 (M-2 fix)
+// =========================================================================
+
+it('detects default from boolean true', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => true],
+    ];
+
+    $result = $field->normalizeValue(null);
+
+    expect($result)->not->toBeNull()
+        ->and($result->label)->toBe('Red');
+});
+
+it('detects default from string "1" (editable table checkbox)', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => '1'],
+    ];
+
+    $result = $field->normalizeValue(null);
+
+    expect($result)->not->toBeNull()
+        ->and($result->label)->toBe('Red');
+});
+
+it('does not treat empty string as default', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => ''],
+    ];
+
+    $result = $field->normalizeValue(null);
+
+    expect($result)->toBeNull();
+});
+
+it('does not treat zero as default', function () {
+    $field = new ColourSwatches();
+    $field->options = [
+        ['label' => 'Red', 'color' => '#f00', 'class' => '', 'default' => 0],
+    ];
+
+    $result = $field->normalizeValue(null);
+
+    expect($result)->toBeNull();
+});

--- a/tests/Unit/Fields/ColourSwatchesConstructorTest.php
+++ b/tests/Unit/Fields/ColourSwatchesConstructorTest.php
@@ -56,6 +56,56 @@ it('serializes a ColourSwatchesModel to array', function () {
         ->and($result['default'])->toBeTrue();
 });
 
+it('enriches a model with class and default from the matching option', function () {
+    // The CP input only posts label, color, and handle, so the stored value
+    // must be enriched from the field's option definitions on save
+    $model = new \percipiolondon\colourswatches\models\ColourSwatches(
+        \craft\helpers\Json::encode([
+            'handle' => 'red',
+            'label' => 'Red',
+            'color' => '#ef4444',
+        ])
+    );
+
+    $field = new ColourSwatches([
+        'options' => [
+            ['label' => 'Red', 'handle' => 'red', 'color' => '#ef4444', 'class' => 'text-red', 'default' => true],
+            ['label' => 'Blue', 'handle' => 'blue', 'color' => '#3b82f6', 'class' => 'text-blue', 'default' => false],
+        ],
+    ]);
+
+    $result = $field->serializeValue($model);
+
+    expect($result)->toBeArray()
+        ->and($result['handle'])->toBe('red')
+        ->and($result['class'])->toBe('text-red')
+        ->and($result['default'])->toBeTrue();
+});
+
+it('preserves a model value that matches no option instead of swapping to default', function () {
+    $model = new \percipiolondon\colourswatches\models\ColourSwatches(
+        \craft\helpers\Json::encode([
+            'handle' => 'legacy',
+            'label' => 'Legacy',
+            'color' => '#123456',
+            'class' => 'text-legacy',
+        ])
+    );
+
+    $field = new ColourSwatches([
+        'options' => [
+            ['label' => 'Blue', 'handle' => 'blue', 'color' => '#3b82f6', 'class' => 'text-blue', 'default' => true],
+        ],
+    ]);
+
+    $result = $field->serializeValue($model);
+
+    expect($result)->toBeArray()
+        ->and($result['handle'])->toBe('legacy')
+        ->and($result['label'])->toBe('Legacy')
+        ->and($result['class'])->toBe('text-legacy');
+});
+
 // =========================================================================
 // serializeValue does NOT mutate field state (H-1 fix)
 // =========================================================================

--- a/tests/Unit/Fields/HandleGenerationTest.php
+++ b/tests/Unit/Fields/HandleGenerationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use craft\helpers\StringHelper;
+
+/**
+ * Tests that handle generation is consistent between PHP and Twig.
+ *
+ * The PHP field class uses StringHelper::toCamelCase() in _generateHandle().
+ * The Twig templates must use |camel (not |kebab) to match.
+ * These tests verify the PHP side produces expected handles.
+ */
+
+// =========================================================================
+// Handle generation consistency
+// =========================================================================
+
+it('generates camelCase handle from simple label', function () {
+    expect(StringHelper::toCamelCase('Red'))->toBe('red');
+});
+
+it('generates camelCase handle from multi-word label', function () {
+    expect(StringHelper::toCamelCase('Light Blue'))->toBe('lightBlue');
+});
+
+it('generates camelCase handle from label with slash', function () {
+    expect(StringHelper::toCamelCase('Yellow/Emerald'))->toBe('yellowEmerald');
+});
+
+it('generates camelCase handle from label with special characters', function () {
+    expect(StringHelper::toCamelCase('Red & Blue'))->toBe('redBlue');
+});
+
+it('generates consistent handle for config-file example labels', function () {
+    // These match the example config.php handles
+    expect(StringHelper::toCamelCase('Red'))->toBe('red')
+        ->and(StringHelper::toCamelCase('Amber'))->toBe('amber')
+        ->and(StringHelper::toCamelCase('Green'))->toBe('green')
+        ->and(StringHelper::toCamelCase('Blue'))->toBe('blue')
+        ->and(StringHelper::toCamelCase('Purple'))->toBe('purple')
+        ->and(StringHelper::toCamelCase('Yellow/Emerald'))->toBe('yellowEmerald')
+        ->and(StringHelper::toCamelCase('Red/Amber'))->toBe('redAmber')
+        ->and(StringHelper::toCamelCase('Sky/Rose'))->toBe('skyRose');
+});

--- a/tests/Unit/Fields/HandleGenerationTest.php
+++ b/tests/Unit/Fields/HandleGenerationTest.php
@@ -22,22 +22,26 @@ it('generates camelCase handle from multi-word label', function () {
     expect(StringHelper::toCamelCase('Light Blue'))->toBe('lightBlue');
 });
 
-it('generates camelCase handle from label with slash', function () {
-    expect(StringHelper::toCamelCase('Yellow/Emerald'))->toBe('yellowEmerald');
+it('preserves special characters in handle (slash, ampersand)', function () {
+    // toCamelCase only splits on whitespace/hyphens/underscores, NOT on
+    // slashes or ampersands. Labels with special characters should use
+    // explicit handle keys in config to get clean handles.
+    expect(StringHelper::toCamelCase('Yellow/Emerald'))->toBe('yellow/Emerald')
+        ->and(StringHelper::toCamelCase('Red & Blue'))->toBe('red&Blue');
 });
 
-it('generates camelCase handle from label with special characters', function () {
-    expect(StringHelper::toCamelCase('Red & Blue'))->toBe('redBlue');
-});
-
-it('generates consistent handle for config-file example labels', function () {
-    // These match the example config.php handles
+it('generates consistent handle for simple config-file labels', function () {
     expect(StringHelper::toCamelCase('Red'))->toBe('red')
         ->and(StringHelper::toCamelCase('Amber'))->toBe('amber')
         ->and(StringHelper::toCamelCase('Green'))->toBe('green')
         ->and(StringHelper::toCamelCase('Blue'))->toBe('blue')
-        ->and(StringHelper::toCamelCase('Purple'))->toBe('purple')
-        ->and(StringHelper::toCamelCase('Yellow/Emerald'))->toBe('yellowEmerald')
-        ->and(StringHelper::toCamelCase('Red/Amber'))->toBe('redAmber')
-        ->and(StringHelper::toCamelCase('Sky/Rose'))->toBe('skyRose');
+        ->and(StringHelper::toCamelCase('Purple'))->toBe('purple');
+});
+
+it('requires explicit handles for labels with special characters', function () {
+    // The config.php example uses explicit handles for these:
+    // 'Yellow/Emerald' => 'yellowEmerald', 'Red/Amber' => 'redAmber'
+    // Auto-generation would produce 'yellow/Emerald', 'red/Amber' instead
+    expect(StringHelper::toCamelCase('Yellow/Emerald'))->not->toBe('yellowEmerald')
+        ->and(StringHelper::toCamelCase('Red/Amber'))->not->toBe('redAmber');
 });

--- a/tests/Unit/Fields/SearchKeywordsTest.php
+++ b/tests/Unit/Fields/SearchKeywordsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use craft\base\ElementInterface;
+use craft\helpers\Json;
+use percipiolondon\colourswatches\fields\ColourSwatches;
+use percipiolondon\colourswatches\models\ColourSwatches as ColourSwatchesModel;
+
+// =========================================================================
+// searchKeywords()
+// =========================================================================
+
+function invokeSearchKeywords(ColourSwatches $field, mixed $value): string
+{
+    $element = test()->createMock(ElementInterface::class);
+    $method = new ReflectionMethod($field, 'searchKeywords');
+
+    return $method->invoke($field, $value, $element);
+}
+
+it('returns keywords for a model with a string colour', function () {
+    $model = new ColourSwatchesModel(Json::encode([
+        'handle' => 'red',
+        'label' => 'Red',
+        'color' => '#ef4444',
+        'class' => 'bg-red-500',
+        'default' => false,
+    ]));
+
+    $keywords = invokeSearchKeywords(new ColourSwatches(), $model);
+
+    expect($keywords)->toContain('Red')
+        ->toContain('red')
+        ->toContain('bg-red-500')
+        ->toContain('#ef4444');
+});
+
+it('returns keywords for a model with an array of colours', function () {
+    $model = new ColourSwatchesModel(Json::encode([
+        'handle' => 'redAmber',
+        'label' => 'Red/Amber',
+        'color' => [
+            ['color' => '#ef4444', 'background' => 'bg-red-500'],
+            ['color' => '#f59e0b', 'background' => 'bg-amber-500'],
+        ],
+        'class' => null,
+        'default' => false,
+    ]));
+
+    $keywords = invokeSearchKeywords(new ColourSwatches(), $model);
+
+    expect($keywords)->toContain('Red/Amber')
+        ->toContain('redAmber')
+        ->toContain('#ef4444')
+        ->toContain('#f59e0b');
+});
+
+it('returns an empty string for non-model values', function () {
+    expect(invokeSearchKeywords(new ColourSwatches(), null))->toBe('')
+        ->and(invokeSearchKeywords(new ColourSwatches(), 'red'))->toBe('');
+});

--- a/tests/Unit/Models/ColourSwatchesTest.php
+++ b/tests/Unit/Models/ColourSwatchesTest.php
@@ -1,0 +1,216 @@
+<?php
+
+use craft\helpers\Json;
+use percipiolondon\colourswatches\models\ColourSwatches;
+
+// =========================================================================
+// Construction from JSON
+// =========================================================================
+
+it('constructs from valid JSON with all fields', function () {
+    $data = [
+        'handle' => 'red',
+        'label' => 'Red',
+        'color' => '#ef4444',
+        'class' => 'bg-red-500',
+        'default' => true,
+    ];
+
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->handle)->toBe('red')
+        ->and($model->label)->toBe('Red')
+        ->and($model->color)->toBe('#ef4444')
+        ->and($model->class)->toBe('bg-red-500')
+        ->and($model->default)->toBeTrue();
+});
+
+it('constructs from JSON with missing handle (backwards compat)', function () {
+    $data = [
+        'label' => 'Blue',
+        'color' => '#3b82f6',
+        'class' => '',
+        'default' => false,
+    ];
+
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->handle)->toBeNull()
+        ->and($model->label)->toBe('Blue')
+        ->and($model->color)->toBe('#3b82f6');
+});
+
+it('constructs from JSON with array color (config-file format)', function () {
+    $data = [
+        'label' => 'Red',
+        'handle' => 'red',
+        'color' => [
+            ['color' => '#ef4444', 'background' => 'bg-red-500'],
+        ],
+        'class' => null,
+        'default' => false,
+    ];
+
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->color)->toBeArray()
+        ->and($model->color[0]['color'])->toBe('#ef4444')
+        ->and($model->color[0]['background'])->toBe('bg-red-500');
+});
+
+it('constructs from JSON with gradient (multiple colors)', function () {
+    $data = [
+        'label' => 'Sunset',
+        'handle' => 'sunset',
+        'color' => [
+            ['color' => '#ef4444'],
+            ['color' => '#f59e0b'],
+        ],
+        'default' => false,
+    ];
+
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->color)->toBeArray()
+        ->and($model->color)->toHaveCount(2);
+});
+
+it('handles null value gracefully', function () {
+    $model = new ColourSwatches(null);
+
+    expect($model->handle)->toBeNull()
+        ->and($model->label)->toBe('')
+        ->and($model->color)->toBeNull()
+        ->and($model->default)->toBeFalse()
+        ->and($model->class)->toBe('');
+});
+
+it('handles empty string value gracefully', function () {
+    $model = new ColourSwatches('');
+
+    expect($model->label)->toBe('')
+        ->and($model->color)->toBeNull();
+});
+
+it('handles invalid JSON gracefully', function () {
+    $model = new ColourSwatches('not json');
+
+    expect($model->label)->toBe('')
+        ->and($model->color)->toBeNull();
+});
+
+it('handles JSON without label gracefully', function () {
+    $model = new ColourSwatches(Json::encode(['color' => '#fff']));
+
+    expect($model->label)->toBe('')
+        ->and($model->color)->toBeNull();
+});
+
+// =========================================================================
+// Default field coercion
+// =========================================================================
+
+it('coerces default "1" string to boolean true', function () {
+    $data = ['label' => 'Red', 'color' => '#f00', 'default' => '1'];
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->default)->toBeTrue();
+});
+
+it('coerces default integer 1 to boolean true', function () {
+    $data = ['label' => 'Red', 'color' => '#f00', 'default' => 1];
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->default)->toBeTrue();
+});
+
+it('coerces default "0" string to boolean false', function () {
+    $data = ['label' => 'Red', 'color' => '#f00', 'default' => '0'];
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->default)->toBeFalse();
+});
+
+it('coerces default "" empty string to boolean false', function () {
+    $data = ['label' => 'Red', 'color' => '#f00', 'default' => ''];
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->default)->toBeFalse();
+});
+
+it('defaults missing default field to false', function () {
+    $data = ['label' => 'Red', 'color' => '#f00'];
+    $model = new ColourSwatches(Json::encode($data));
+
+    expect($model->default)->toBeFalse();
+});
+
+// =========================================================================
+// __toString
+// =========================================================================
+
+it('casts to string as the label', function () {
+    $model = new ColourSwatches(Json::encode(['label' => 'Primary Blue', 'color' => '#00f']));
+
+    expect((string)$model)->toBe('Primary Blue');
+});
+
+it('casts to empty string when no label', function () {
+    $model = new ColourSwatches(null);
+
+    expect((string)$model)->toBe('');
+});
+
+// =========================================================================
+// Accessor methods
+// =========================================================================
+
+it('colors() returns the color property', function () {
+    $model = new ColourSwatches(Json::encode(['label' => 'Red', 'color' => '#f00']));
+
+    expect($model->colors())->toBe('#f00');
+});
+
+it('labels() returns the label property', function () {
+    $model = new ColourSwatches(Json::encode(['label' => 'Red', 'color' => '#f00']));
+
+    expect($model->labels())->toBe('Red');
+});
+
+// =========================================================================
+// collection()
+// =========================================================================
+
+it('returns a Collection from array color', function () {
+    $data = [
+        'label' => 'Gradient',
+        'color' => [
+            ['color' => '#ef4444', 'background' => 'bg-red-500'],
+            ['color' => '#3b82f6', 'background' => 'bg-blue-500'],
+        ],
+    ];
+    $model = new ColourSwatches(Json::encode($data));
+
+    $collection = $model->collection();
+
+    expect($collection)->toBeInstanceOf(\Illuminate\Support\Collection::class)
+        ->and($collection)->toHaveCount(2);
+});
+
+it('returns an empty Collection when color is null', function () {
+    $model = new ColourSwatches(null);
+
+    $collection = $model->collection();
+
+    expect($collection)->toBeInstanceOf(\Illuminate\Support\Collection::class)
+        ->and($collection)->toHaveCount(0);
+});
+
+it('returns a Collection from string color', function () {
+    $model = new ColourSwatches(Json::encode(['label' => 'Red', 'color' => '#f00']));
+
+    $collection = $model->collection();
+
+    // String wraps into a single-item collection containing the characters
+    expect($collection)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+});


### PR DESCRIPTION
## 5.2.0 Release

Releases the consolidated audit remediation (PR #157), a serialization regression fix, and an automatic handle-backfill migration. Smoke tested end-to-end on the plugin playground (Craft 5, PHP 8.3), including a simulated legacy (handle-less) value surviving the upgrade path.

> Note: a 5.2.0 version bump existed briefly on `v5` for a test that was never tagged or published (the Plugin Store is on 5.1.0), so this release reclaims the 5.2.0 number and ships every change since 5.1.0.

> **Critical:** includes security fixes, GraphQL breaking changes, and fixes for long-standing data loss issues.

### Security
- XSS via unescaped `|parseRefs|raw` colour values in style attributes (#143)
- JS injection via unescaped field handle in `registerJs()` (#145)

### Bug fixes
- Swatch values now store a stable `handle`; label edits no longer lose saved selections (#141)
- **Automatic upgrade:** a migration (schema 1.5.0) queues batched resave jobs for every element type using a Colour Swatches field, backfilling handles, enriched class/default data, and search keywords on `craft up`
- Saved values are enriched from option definitions again, so the configured CSS class and default flag are stored (regression caught during playground verification)
- `getSerializedFieldValues()` returns serialized arrays instead of models (#137)
- `serializeValue()` no longer mutates field state on multi-site saves (#151)
- Strict comparisons for default detection (#153); duplicate `$paletteOptions` dead code removed (#149)
- Translation file renamed to match the `colour-swatches` handle; Red/Amber example palette colour corrected (#156)

### GraphQL
- Per-field **GraphQL Mode** setting: full swatch data (default, current behaviour) or label-only string (#134)
- Shared `ColourSwatches_SwatchData` type replaces per-field-handle types, avoiding schema collisions (#152)
- Colour values no longer double-JSON-encoded

### Added
- Search keyword support: label, handle, CSS class, and colour values (#113)
- `defineRules()` validation on the value model (#148)
- Pest unit test suite (54 tests)

### Housekeeping
- Collection macro moved to plugin `init()` (#150)
- Docblocks, section headers, `@author`/`@since`, short nullable notation, `str_contains()` (#146, #147, #154, #155, #156)
- Value model accessors `colors()`/`labels()`/`default()`/`class()` deprecated for removal in 6.0
- README rewritten for Craft 5: upgrade notes, corrected handle examples, current GraphQL docs
- PHPStan level 5 passes clean

### Breaking changes (GraphQL)
- Type name changed from per-field-handle names to `ColourSwatches_SwatchData`; update inline fragments
- Colour values are no longer double-encoded; remove any client-side double-parse

### Issues to close on release
#113, #134, #137, #141, #143, #145, #146, #147, #148, #149, #150, #151, #152, #153, #154, #155, #156
